### PR TITLE
Remove zarr runtime dependency, use tensorstore + direct JSON for met…

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -232,7 +232,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/de/4a/b795ccf23430801970e606215cec0074030b37154918d3b5f54efc48437d/deflate-0.8.1-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/65/89601dcc7383f0e5109e59eab90677daa9abb260d821570cd6089c8894bf/distributed-2025.5.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/b7/28dff0bc2f992df437aaeeaeffba8f2f1ec031f054cedfc0390ea4300370/dracopy-2.0.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/87/5af5dc3b691f83a1647dfac7899a5e48b245d005c6a87998a71a6c17fa57/fastremap-1.18.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -266,7 +265,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/aa/05/8a699e19dc5f3549042cac25aa378240c9850ef453ff63609a91d256748b/neuroglancer-2.41.2-cp310-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/53/78c98ef5c8b2b784453487f3e4d6c017b20747c58b470393e230c78d18e8/numcodecs-0.16.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/95/a9/4f25a14d23f0786b64875b91784607c2277eff25d48f915e39ff0cff505a/oauth2client-4.1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/87/5ddeb7fc1fbd9004aeccab08426f34c81a5b4c25c7061281862b015fce2b/orjson-3.11.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
@@ -304,10 +302,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/83/72e812f772daee66651f468c7b2535fa05eac27db26df7e614cae823c832/trimesh-4.11.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/b0/fd7b6444b998ea21189f6590bbd0075b741176b050212dd6d80c6a93aefe/zmesh-1.11.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c2/b0/956902e5e1302f8c5d124e219c6bf214e2649f92ad5fce85b05c039a04c9/zope_event-6.1-py3-none-any.whl
@@ -497,7 +493,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9d/8a/451f1c7cd1d517441c5df6c44726a3fc121b2983800a40e282259f4fdf84/deflate-0.8.1-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/65/89601dcc7383f0e5109e59eab90677daa9abb260d821570cd6089c8894bf/distributed-2025.5.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/59/6c2c83cb8a0f56f61ca297241abb51f4157a0eebebfc24f213e707996857/dracopy-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/bd/42883df958b4bdf7c67e58791ade6b67ed63ca831907e7eb039f3da99e55/fastremap-1.18.0-cp312-cp312-macosx_11_0_arm64.whl
@@ -531,7 +526,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/31/aeeb597e920204d970f0b304a0bff6cd1d37a60919466ddd21aae4fb7a71/neuroglancer-2.41.2-cp310-abi3-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/f5/6c/86644987505dcb90ba6d627d6989c27bafb0699f9fd00187e06d05ea8594/numcodecs-0.16.5-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/95/a9/4f25a14d23f0786b64875b91784607c2277eff25d48f915e39ff0cff505a/oauth2client-4.1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/f6/8d58b32ab32d9215973a1688aebd098252ee8af1766c0e4e36e7831f0295/orjson-3.11.8-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
@@ -569,10 +563,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/83/72e812f772daee66651f468c7b2535fa05eac27db26df7e614cae823c832/trimesh-4.11.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/97/5fc3e8c72a1011575456c2ea8815e98406022f5d99d05cd7578f7146de4c/zmesh-1.11.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c2/b0/956902e5e1302f8c5d124e219c6bf214e2649f92ad5fce85b05c039a04c9/zope_event-6.1-py3-none-any.whl
@@ -810,7 +802,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/de/4a/b795ccf23430801970e606215cec0074030b37154918d3b5f54efc48437d/deflate-0.8.1-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/65/89601dcc7383f0e5109e59eab90677daa9abb260d821570cd6089c8894bf/distributed-2025.5.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/b7/28dff0bc2f992df437aaeeaeffba8f2f1ec031f054cedfc0390ea4300370/dracopy-2.0.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/87/5af5dc3b691f83a1647dfac7899a5e48b245d005c6a87998a71a6c17fa57/fastremap-1.18.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -843,7 +834,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/aa/05/8a699e19dc5f3549042cac25aa378240c9850ef453ff63609a91d256748b/neuroglancer-2.41.2-cp310-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/53/78c98ef5c8b2b784453487f3e4d6c017b20747c58b470393e230c78d18e8/numcodecs-0.16.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/95/a9/4f25a14d23f0786b64875b91784607c2277eff25d48f915e39ff0cff505a/oauth2client-4.1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/87/5ddeb7fc1fbd9004aeccab08426f34c81a5b4c25c7061281862b015fce2b/orjson-3.11.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
@@ -880,7 +870,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/24/83/72e812f772daee66651f468c7b2535fa05eac27db26df7e614cae823c832/trimesh-4.11.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/b0/fd7b6444b998ea21189f6590bbd0075b741176b050212dd6d80c6a93aefe/zmesh-1.11.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c2/b0/956902e5e1302f8c5d124e219c6bf214e2649f92ad5fce85b05c039a04c9/zope_event-6.1-py3-none-any.whl
@@ -1069,7 +1058,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9d/8a/451f1c7cd1d517441c5df6c44726a3fc121b2983800a40e282259f4fdf84/deflate-0.8.1-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/65/89601dcc7383f0e5109e59eab90677daa9abb260d821570cd6089c8894bf/distributed-2025.5.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/59/6c2c83cb8a0f56f61ca297241abb51f4157a0eebebfc24f213e707996857/dracopy-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/bd/42883df958b4bdf7c67e58791ade6b67ed63ca831907e7eb039f3da99e55/fastremap-1.18.0-cp312-cp312-macosx_11_0_arm64.whl
@@ -1102,7 +1090,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/31/aeeb597e920204d970f0b304a0bff6cd1d37a60919466ddd21aae4fb7a71/neuroglancer-2.41.2-cp310-abi3-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/f5/6c/86644987505dcb90ba6d627d6989c27bafb0699f9fd00187e06d05ea8594/numcodecs-0.16.5-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/95/a9/4f25a14d23f0786b64875b91784607c2277eff25d48f915e39ff0cff505a/oauth2client-4.1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/f6/8d58b32ab32d9215973a1688aebd098252ee8af1766c0e4e36e7831f0295/orjson-3.11.8-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
@@ -1139,7 +1126,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/24/83/72e812f772daee66651f468c7b2535fa05eac27db26df7e614cae823c832/trimesh-4.11.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/97/5fc3e8c72a1011575456c2ea8815e98406022f5d99d05cd7578f7146de4c/zmesh-1.11.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c2/b0/956902e5e1302f8c5d124e219c6bf214e2649f92ad5fce85b05c039a04c9/zope_event-6.1-py3-none-any.whl
@@ -6088,7 +6074,7 @@ packages:
 - pypi: .
   name: mesh-n-bone
   version: 0.1.0
-  sha256: 5d86bec16c7934e6751325bdaf96625446e8a3356966163df7b3a5d0969d5176
+  sha256: 3a4417ab47aec5fbd87c5a913ef93fe3d58c0e8e65c3a30fca9e0a5072c13880
   requires_dist:
   - numpy
   - trimesh>=4.6.8
@@ -6104,7 +6090,6 @@ packages:
   - zmesh
   - funlib-geometry
   - tensorstore
-  - zarr>=3.0.8
   - numba
   - neuroglancer
   - fastremap
@@ -6116,6 +6101,7 @@ packages:
   - mkdocs-material ; extra == 'docs'
   - mkdocstrings[python] ; extra == 'docs'
   - pytest ; extra == 'test'
+  - zarr>=3.0.8 ; extra == 'test'
   requires_python: '>=3.10'
   editable: true
 - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -8095,11 +8081,6 @@ packages:
   - openctm ; extra == 'deprecated'
   - trimesh[deprecated,easy,recommend,test,test-more] ; extra == 'all'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
-  name: typing-extensions
-  version: 4.15.0
-  sha256: f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
-  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
   md5: 0caa1af407ecff61170c9437a808404d

--- a/pixi.toml
+++ b/pixi.toml
@@ -33,11 +33,13 @@ zmesh = "*"
 funlib-geometry = "*"
 tensorstore = "*"
 Pillow = "*"
-zarr = ">=3.0.8"
 neuroglancer = "*"
 fastremap = "*"
 pybind11-rdp = "*"
 shapely = "*"
+
+[feature.test.pypi-dependencies]
+zarr = ">=3.0.8"
 
 [feature.test.dependencies]
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
   # Volumetric data
   "funlib.geometry",
   "tensorstore",
-  "zarr>=3.0.8",
   "numba",
 
   # Skeletonization
@@ -68,6 +67,7 @@ docs = [
 ]
 test = [
   "pytest",
+  "zarr>=3.0.8",
 ]
 
 [project.urls]

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -12,11 +12,9 @@ import shutil
 import trimesh
 import json
 import pymeshlab
-import zarr
-
 from mesh_n_bone.util import dask_util
 from mesh_n_bone.util.logging import Timing_Messager
-from mesh_n_bone.util.zarr_io import open_dataset, split_dataset_path, read_raw_voxel_size
+from mesh_n_bone.util.zarr_io import open_dataset, split_dataset_path, read_raw_voxel_size, _read_attrs
 from mesh_n_bone.util.image_data_interface import open_ds_tensorstore, to_ndarray_tensorstore
 from mesh_n_bone.meshify.downsample import (
     downsample_labels_3d_suppress_zero,
@@ -45,7 +43,7 @@ def _read_ome_ngff_transform(input_path):
     (voxel_size, offset, coordinate_units) in ZYX order,
     or (None, None, None) if not found.
     """
-    # Find the zarr root and dataset path within it
+    # Find the zarr/n5 root and dataset path within it
     for ext in [".zarr", ".n5"]:
         if ext in input_path:
             parts = input_path.split(ext + "/")
@@ -61,13 +59,14 @@ def _read_ome_ngff_transform(input_path):
     parent_path = os.path.dirname(dataset_path)
 
     try:
-        root = zarr.open(zarr_root_path, mode="r")
+        # Read parent group attributes directly from JSON metadata files
         if parent_path:
-            parent_group = root[parent_path]
+            parent_dir = os.path.join(zarr_root_path, parent_path)
         else:
-            parent_group = root
+            parent_dir = zarr_root_path
 
-        multiscales = parent_group.attrs.get("multiscales")
+        parent_attrs = _read_attrs(parent_dir)
+        multiscales = parent_attrs.get("multiscales")
         if not multiscales:
             return None, None, None
 

--- a/src/mesh_n_bone/util/cellmap_array.py
+++ b/src/mesh_n_bone/util/cellmap_array.py
@@ -1,4 +1,4 @@
-"""Lightweight wrapper around a zarr.Array with physical coordinate metadata.
+"""Lightweight wrapper around array metadata with physical coordinate support.
 
 Replaces funlib.persistence.Array for read-only use cases.
 """
@@ -8,24 +8,27 @@ from funlib.geometry import Coordinate, Roi
 
 
 class CellMapArray:
-    """Wrapper around a zarr.Array providing ROI-based indexing.
+    """Wrapper providing ROI-based indexing over array metadata.
 
     Converts between physical coordinates and voxel indices,
     replacing funlib.persistence.Array for read-only workflows.
     """
 
-    def __init__(self, data, voxel_size, offset):
+    def __init__(self, data, voxel_size, offset, dataset_path=None):
         """
         Parameters
         ----------
-        data : zarr.Array
-            Underlying zarr array.
+        data : ArrayMetadata
+            Metadata container with shape, dtype, chunks, and attrs.
         voxel_size : Coordinate or tuple
             Voxel dimensions in physical units.
         offset : Coordinate or tuple
             Array origin in physical units.
+        dataset_path : str or None
+            Filesystem path to the dataset (used for parent attr lookup).
         """
         self.data = data
+        self._dataset_path = dataset_path
         self.voxel_size = (
             voxel_size if isinstance(voxel_size, Coordinate) else Coordinate(voxel_size)
         )
@@ -45,23 +48,3 @@ class CellMapArray:
     @property
     def shape(self):
         return self.data.shape
-
-    def _to_slices(self, roi):
-        """Convert a physical ROI to voxel slices."""
-        voxel_roi = (roi - self.roi.offset) / self.voxel_size
-        return voxel_roi.to_slices()
-
-    def to_ndarray(self, roi, fill_value=0):
-        """Read data for a physical ROI, padding with fill_value if needed."""
-        shape = roi.shape / self.voxel_size
-        data = np.zeros(shape, dtype=self.dtype)
-        if fill_value != 0:
-            data[:] = fill_value
-
-        shared_roi = self.roi.intersect(roi)
-        if not shared_roi.empty:
-            target_slices = ((shared_roi - roi.offset) / self.voxel_size).to_slices()
-            source_slices = self._to_slices(shared_roi)
-            data[target_slices] = self.data[source_slices]
-
-        return data

--- a/src/mesh_n_bone/util/zarr_io.py
+++ b/src/mesh_n_bone/util/zarr_io.py
@@ -1,14 +1,79 @@
-"""Zarr dataset opening utilities, replacing funlib.persistence.open_ds."""
+"""Dataset opening utilities using direct JSON metadata reading and TensorStore."""
 
+import json
 import logging
 import os
 
-import zarr
 from funlib.geometry import Coordinate
 
 from mesh_n_bone.util.cellmap_array import CellMapArray
 
 logger = logging.getLogger(__name__)
+
+
+class ArrayMetadata:
+    """Metadata container replacing zarr.Array for CellMapArray.
+
+    Provides the same interface as zarr.Array for the properties
+    that CellMapArray accesses: ``shape``, ``dtype``, ``chunks``,
+    and ``attrs``.
+    """
+
+    def __init__(self, shape, dtype, chunks, attrs):
+        self.shape = shape
+        self.dtype = dtype
+        self.chunks = chunks
+        self.attrs = attrs
+
+
+def _read_json_file(path):
+    """Read a JSON file from a local path.
+
+    Parameters
+    ----------
+    path : str
+        Path to the JSON file.
+
+    Returns
+    -------
+    dict or None
+        Parsed JSON, or ``None`` if the file does not exist or is
+        not valid JSON.
+    """
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+
+
+def _is_n5(path):
+    """Return True if *path* refers to an N5 container."""
+    return path.rfind(".n5") > path.rfind(".zarr")
+
+
+def _read_attrs(dataset_path):
+    """Read custom attributes from the metadata file at *dataset_path*.
+
+    Supports N5 (``attributes.json``), zarr v3 (``zarr.json``),
+    and zarr v2 (``.zattrs``).
+
+    Parameters
+    ----------
+    dataset_path : str
+        Path to the dataset directory.
+
+    Returns
+    -------
+    dict
+        Parsed attributes (may be empty).
+    """
+    if _is_n5(dataset_path):
+        return _read_json_file(os.path.join(dataset_path, "attributes.json")) or {}
+    zarr_json = _read_json_file(os.path.join(dataset_path, "zarr.json"))
+    if zarr_json is not None:
+        return zarr_json.get("attributes", {})
+    return _read_json_file(os.path.join(dataset_path, ".zattrs")) or {}
 
 
 def split_dataset_path(dataset_path):
@@ -37,7 +102,8 @@ def split_dataset_path(dataset_path):
 def open_dataset(filename, ds_name, mode="r"):
     """Open a zarr/n5 dataset and return a CellMapArray.
 
-    Supports zarr v2, v3, and N5 formats.
+    Uses direct JSON file reading for metadata and TensorStore
+    for array shape, dtype, and chunk layout.
 
     Parameters
     ----------
@@ -53,34 +119,44 @@ def open_dataset(filename, ds_name, mode="r"):
     CellMapArray
         Array wrapper with physical coordinate metadata.
     """
+    from mesh_n_bone.util.image_data_interface import open_ds_tensorstore
+
     logger.debug("opening dataset %s in %s", ds_name, filename)
     full_path = os.path.join(filename, ds_name) if ds_name else filename
+
+    attrs = _read_attrs(full_path)
+
     try:
-        ds = zarr.open_array(full_path, mode=mode)
+        ts_ds = open_ds_tensorstore(full_path, mode=mode)
     except Exception as e:
         logger.error("failed to open %s/%s: %s", filename, ds_name, e)
         raise
 
-    voxel_size, offset = _read_voxel_size_offset(ds)
-    return CellMapArray(ds, voxel_size, offset)
+    shape = tuple(ts_ds.shape)
+    dtype = ts_ds.dtype.numpy_dtype
+    chunks = tuple(ts_ds.chunk_layout.read_chunk.shape)
+
+    data = ArrayMetadata(shape, dtype, chunks, attrs)
+    voxel_size, offset = _read_voxel_size_offset(data)
+    return CellMapArray(data, voxel_size, offset, dataset_path=full_path)
 
 
-def _read_voxel_size_offset(ds):
-    """Read voxel_size and offset from a zarr array's attributes.
+def _read_voxel_size_offset(data):
+    """Read voxel_size and offset from array attributes.
 
     Checks funlib-style, N5, and OME-Zarr metadata formats.
 
     Parameters
     ----------
-    ds : zarr.Array
-        Opened zarr array.
+    data : ArrayMetadata
+        Metadata container with ``.attrs`` dict.
 
     Returns
     -------
     tuple[Coordinate, Coordinate]
         ``(voxel_size, offset)``
     """
-    attrs = dict(ds.attrs)
+    attrs = data.attrs
 
     if "resolution" in attrs:
         voxel_size = Coordinate(int(v) for v in attrs["resolution"])
@@ -91,7 +167,7 @@ def _read_voxel_size_offset(ds):
             int(v) for v in attrs["pixelResolution"]["dimensions"]
         )
     else:
-        voxel_size = Coordinate(1 for _ in ds.shape)
+        voxel_size = Coordinate(1 for _ in data.shape)
 
     if "offset" in attrs:
         offset = Coordinate(int(v) for v in attrs["offset"])
@@ -102,14 +178,14 @@ def _read_voxel_size_offset(ds):
 
 
 def read_raw_voxel_size(ds):
-    """Read the original float voxel_size from zarr attributes.
+    """Read the original float voxel_size from dataset attributes.
 
-    Unlike `_read_voxel_size_offset`, preserves float precision
+    Unlike ``_read_voxel_size_offset``, preserves float precision
     (funlib.geometry.Coordinate truncates to int).
 
     Parameters
     ----------
-    ds : CellMapArray or object with ``.data.attrs``
+    ds : CellMapArray
         Dataset wrapper.
 
     Returns
@@ -117,7 +193,7 @@ def read_raw_voxel_size(ds):
     tuple[float, ...]
         True voxel size as floats.
     """
-    attrs = dict(ds.data.attrs)
+    attrs = ds.data.attrs
 
     if "voxel_size" in attrs:
         return tuple(float(v) for v in attrs["voxel_size"])
@@ -146,28 +222,27 @@ def _extract_ome_scale(attrs):
 
 
 def _read_parent_attrs(ds):
-    """Try to read attributes from the parent zarr group."""
-    try:
-        store = ds.data.store
-        store_root = getattr(store, "root", None)
-        if store_root:
-            store_root = str(store_root)
-            if store_root.startswith("file://"):
-                store_root = store_root[len("file://"):]
+    """Read attributes from the parent directory of a dataset.
 
-        array_name = getattr(ds.data, "name", None) or getattr(ds.data, "path", "")
-        array_name = array_name.strip("/")
+    Parameters
+    ----------
+    ds : CellMapArray
+        Dataset wrapper. Uses the stored ``_dataset_path`` if
+        available, otherwise falls back to filesystem path
+        navigation.
 
-        if array_name and store_root:
-            parent_path = "/".join(array_name.split("/")[:-1])
-            if parent_path:
-                parent = zarr.open_group(store, mode="r", path=parent_path)
-                return dict(parent.attrs)
-        elif store_root:
-            parent_dir = os.path.dirname(store_root)
-            if os.path.isdir(parent_dir):
-                parent = zarr.open_group(parent_dir, mode="r")
-                return dict(parent.attrs)
-    except Exception:
-        pass
+    Returns
+    -------
+    dict or None
+        Parent directory attributes, or ``None`` if unavailable.
+    """
+    dataset_path = getattr(ds, "_dataset_path", None)
+    if dataset_path is None:
+        return None
+
+    parent = os.path.dirname(dataset_path)
+    if parent and parent != dataset_path:
+        attrs = _read_attrs(parent)
+        if attrs:
+            return attrs
     return None


### PR DESCRIPTION
…adata

Replace zarr.open_array() with direct JSON attribute file reading (attributes.json for N5, .zattrs for zarr v2, zarr.json for zarr v3) and tensorstore for shape/dtype/chunk info. This fixes N5 support broken by zarr v3 dropping N5 and removes a heavy runtime dependency.

- zarr_io.py: read metadata from JSON files, get array info from tensorstore
- cellmap_array.py: wrap ArrayMetadata instead of zarr.Array
- meshify.py: replace zarr.open() with _read_attrs() for OME-NGFF
- Move zarr to test-only dependency