### PR TITLE
Fix blockwise mesh alignment for offset datasets and N5 axis order

### DIFF
--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -212,6 +212,16 @@ def _get_chunked_mesh_worker(block, tmpdirname, config):
 
         if config["use_fixed_edge_simplification"] and config["do_simplification"]:
             mesh_tri = trimesh.Trimesh(vertices=mesh.vertices, faces=mesh.faces)
+            # Shift by half a voxel so clip planes in
+            # remove_boundary_vertices land exactly on the MC crossing
+            # vertices (midpoints between padding and unpadded voxels).
+            # This makes both adjacent blocks clip at the same world
+            # plane, producing matching boundary vertices.  Padding
+            # parallel-edge vertices end up strictly outside [0,
+            # block_size] and are removed by the strict > check.
+            half_pad = 0.5 * np.array(output_voxel_size)[::-1]
+            mesh_tri.vertices -= half_pad
+
             stage_1_reduction, _ = staged_reductions(
                 config["target_reduction"],
                 config["stage_1_reduction_fraction"],
@@ -231,7 +241,8 @@ def _get_chunked_mesh_worker(block, tmpdirname, config):
                 verbose=False,
                 fix_edges=True,
             )
-            mesh_tri_simplified.vertices += block_offset[::-1] + ds_shift[::-1]
+            half_pad_offset = block_offset + 0.5 * np.array(output_voxel_size)
+            mesh_tri_simplified.vertices += half_pad_offset[::-1] + ds_shift[::-1]
 
             mesh_simplified = CloudVolumeMesh(
                 mesh_tri_simplified.vertices,
@@ -975,11 +986,12 @@ class Meshify:
                 offset=self.roi.offset[::-1],
             )
             if self.use_fixed_edge_simplification:
-                # Fixed-edge simplification clips block meshes at exact
-                # chunk boundaries.  deduplicate_chunk_boundaries merges
-                # vertices at mod(pos, chunk_size)==0; merge_vertices
-                # catches any remaining near-duplicates from slice
-                # interpolation.
+                # The half-voxel shift places clip planes on the MC
+                # crossing vertices between padding and unpadded voxels.
+                # Both adjacent blocks clip at the same world plane and
+                # produce identical boundary vertices.  merge_vertices
+                # merges them even though they aren't at exact chunk-
+                # size multiples (where deduplicate looks).
                 tri_tmp = trimesh.Trimesh(
                     vertices=mesh.vertices, faces=mesh.faces, process=False
                 )

--- a/src/mesh_n_bone/util/image_data_interface.py
+++ b/src/mesh_n_bone/util/image_data_interface.py
@@ -146,8 +146,13 @@ def to_ndarray_tensorstore(dataset, roi, voxel_size, offset, swap_axes=False,
     if offset is None:
         offset = Coordinate(np.zeros(roi.dims, dtype=int))
 
-    roi = roi.snap_to_grid(voxel_size)
+    # Subtract offset first so snap_to_grid aligns to the dataset's
+    # voxel grid (offset + k*voxel_size), not multiples of voxel_size.
+    # Without this, datasets with non-zero offset (e.g., 60nm) get
+    # misaligned reads where adjacent blocks read different physical
+    # voxels for what should be overlap.
     roi -= offset
+    roi = roi.snap_to_grid(voxel_size)
     roi /= voxel_size
 
     roi_slices = roi.to_slices()

--- a/src/mesh_n_bone/util/image_data_interface.py
+++ b/src/mesh_n_bone/util/image_data_interface.py
@@ -132,6 +132,9 @@ def to_ndarray_tensorstore(dataset, roi, voxel_size, offset, swap_axes=False,
             roi = Roi(roi.begin[::-1], roi.shape[::-1])
         if offset:
             offset = Coordinate(offset[::-1])
+        # Reverse voxel_size too — the division below uses it on the
+        # already-reversed ROI, so they must be in the same axis order.
+        voxel_size = Coordinate(reversed(tuple(voxel_size)))
 
     domain = dataset.domain
     if len(domain) > 3:

--- a/src/mesh_n_bone/util/zarr_io.py
+++ b/src/mesh_n_bone/util/zarr_io.py
@@ -136,6 +136,13 @@ def open_dataset(filename, ds_name, mode="r"):
     dtype = ts_ds.dtype.numpy_dtype
     chunks = tuple(ts_ds.chunk_layout.read_chunk.shape)
 
+    # N5 stores shape in XYZ order, but funlib expects ZYX.  Reverse so
+    # ROI computation (shape * voxel_size) and chunk-aligned operations
+    # use consistent axis order.
+    if _is_n5(full_path):
+        shape = shape[::-1]
+        chunks = chunks[::-1]
+
     data = ArrayMetadata(shape, dtype, chunks, attrs)
     voxel_size, offset = _read_voxel_size_offset(data)
     return CellMapArray(data, voxel_size, offset, dataset_path=full_path)
@@ -163,9 +170,16 @@ def _read_voxel_size_offset(data):
     elif "voxel_size" in attrs:
         voxel_size = Coordinate(int(v) for v in attrs["voxel_size"])
     elif "pixelResolution" in attrs:
-        voxel_size = Coordinate(
-            int(v) for v in attrs["pixelResolution"]["dimensions"]
-        )
+        # N5 pixelResolution.dimensions is in XYZ order, but funlib
+        # Coordinates are ZYX.  Prefer transform.scale (already ZYX
+        # via transform.axes) when available; otherwise reverse
+        # pixelResolution.
+        transform = attrs.get("transform", {})
+        if "scale" in transform:
+            voxel_size = Coordinate(int(round(v)) for v in transform["scale"])
+        else:
+            dims = list(attrs["pixelResolution"]["dimensions"])
+            voxel_size = Coordinate(int(round(v)) for v in reversed(dims))
     else:
         voxel_size = Coordinate(1 for _ in data.shape)
 
@@ -202,7 +216,11 @@ def read_raw_voxel_size(ds):
         return tuple(float(v) for v in attrs["resolution"])
 
     if "pixelResolution" in attrs:
-        return tuple(float(v) for v in attrs["pixelResolution"]["dimensions"])
+        transform = attrs.get("transform", {})
+        if "scale" in transform:
+            return tuple(float(v) for v in transform["scale"])
+        dims = list(attrs["pixelResolution"]["dimensions"])
+        return tuple(float(v) for v in reversed(dims))
 
     # Check OME-Zarr multiscales on parent group
     parent_attrs = _read_parent_attrs(ds)

--- a/tests/test_integration_meshify.py
+++ b/tests/test_integration_meshify.py
@@ -392,6 +392,49 @@ class TestMeshifyFixedEdgeSimplification:
         )
         assert mesh.volume > 0
 
+    def test_cross_block_fixed_edge_is_watertight(self, tmp_output_dir):
+        """Fixed-edge simplification across processing blocks is watertight.
+
+        Forces the object to span multiple processing blocks by setting
+        read_write_block_shape_pixels smaller than the object.  The
+        sphere surface crosses block boundaries, exercising the
+        boundary clipping and vertex deduplication path.
+        """
+        vol = np.zeros((32, 32, 32), dtype=np.uint64)
+        center = np.array([16, 16, 16], dtype=float)
+        for z in range(32):
+            for y in range(32):
+                for x in range(32):
+                    if np.linalg.norm(np.array([z, y, x], dtype=float) - center) < 12:
+                        vol[z, y, x] = 1
+
+        input_path = _create_zarr_volume(
+            tmp_output_dir, vol, voxel_size=(4, 4, 4), chunk_shape=(8, 8, 8)
+        )
+        output_dir = os.path.join(tmp_output_dir, "output")
+
+        m = Meshify(
+            input_path=input_path,
+            output_directory=output_dir,
+            num_workers=1,
+            do_analysis=False,
+            check_mesh_validity=False,
+            use_fixed_edge_simplification=True,
+            do_simplification=True,
+            target_reduction=0.9,
+            n_smoothing_iter=5,
+            remove_smallest_components=False,
+            read_write_block_shape_pixels=[8, 8, 8],
+        )
+        m.get_meshes()
+
+        mesh = trimesh.load(os.path.join(output_dir, "meshes", "1.ply"))
+        assert mesh.is_watertight, (
+            "Fixed-edge simplified mesh should be watertight when object "
+            "surface crosses processing block boundaries"
+        )
+        assert mesh.volume > 0
+
     def test_cross_chunk_fixed_edge_no_spikes(self, tmp_output_dir):
         """Fixed-edge simplification should not produce spike edges."""
         vol = np.zeros((32, 32, 32), dtype=np.uint64)


### PR DESCRIPTION
## Summary

Fixes three independent bugs in the blockwise mesh generation pipeline that were producing broken meshes (open seams, missing geometry, distortion). Each is a small, targeted change.

### 1. Snap ROI to dataset voxel grid, not multiples of voxel_size
[image_data_interface.py](src/mesh_n_bone/util/image_data_interface.py)

`snap_to_grid` aligned to multiples of `voxel_size` instead of the dataset's actual voxel grid (`offset + k*voxel_size`). For datasets with non-zero offset (e.g., thymus-1 at 60nm), interior block reads started one voxel earlier than the requested ROI, while the worker still used the original padded begin to compute world coords. Adjacent blocks ended up shifted by 128nm relative to each other.

This caused ~53% of boundary-crossing meshes in jrc_mus-thymus-1 to have open seams.

### 2. Fix N5 axis order for shape, voxel_size, and swap_axes
[zarr_io.py](src/mesh_n_bone/util/zarr_io.py), [image_data_interface.py](src/mesh_n_bone/util/image_data_interface.py)

N5 stores shape and `pixelResolution` in XYZ, but funlib Coordinates are ZYX. Three mismatches were corrupting hela-2's meshes:
- Shape from tensorstore (XYZ) was used directly for ROI computation, giving the wrong physical extent (60000×6400×25472 instead of 31840×6400×48000). Most of the nucleus was outside the iterated blocks ⇒ "half missing" geometry.
- `pixelResolution.dimensions` (XYZ) was treated as ZYX, swapping X and Z voxel sizes ⇒ visible distortion in the rendered mesh.
- The `swap_axes` path in `to_ndarray_tensorstore` reversed ROI/offset but not voxel_size, causing inconsistent axis order in the read.

Prefer `transform.scale` (already ZYX via `transform.axes`) when available; otherwise reverse `pixelResolution`. Use `round()` instead of `int()` to handle non-integer voxel sizes (5.24 → 5 instead of truncating).

### 3. Shift fixed-edge clip planes by half a voxel
[meshify.py](src/mesh_n_bone/meshify/meshify.py)

`remove_boundary_vertices` clipped at `[0, block_size_world]` in local coordinates. With `block.roi.get_begin()` returning the padded begin (1 voxel before unpadded), the upper clip landed 1 voxel before the actual block boundary and the lower clip at 0 was a no-op (all MC vertices are ≥ 0). Adjacent blocks then had mismatched boundary geometry — one side had interpolated vertices from `slice_mesh_plane`, the other kept original MC vertices. `merge_vertices` caught some pairs but not others.

Shifting MC vertices by `-0.5*voxel_size` before clipping aligns the clip planes with the MC face boundaries between padding and unpadded voxels. Both adjacent blocks now clip at the same world plane, producing matching interpolated boundary vertices that merge reliably. Net world-coordinate vertex positions are unchanged (the half-voxel offset is added back in the world-coord shift).

Adds an integration test that forces blocks smaller than the object so the boundary-merging path is actually exercised. The previous test happened to fit the entire volume in a single block, so cross-block merging was never tested.

## Test plan
- [x] Existing test suite passes (192 passed, 3 skipped)
- [x] New `test_cross_block_fixed_edge_is_watertight` passes
- [x] Verified on real thymus-1 data: meshes 13577 and 13660 are now watertight (euler=2, 0 boundary edges)
- [x] Verified hela-2 dataset reads with correct ROI extent
- [x] Re-run full thymus-1 production pipeline; spot-check meshes for closed boundaries
- [x] Re-run full hela-2 production pipeline; spot-check mesh 1 for full coverage and correct shape