### PR TITLE
Read OME-Zarr v0.5 voxel sizes; harden multiscales fallback; expose chunk-face threshold

### DIFF
--- a/src/mesh_n_bone/config.py
+++ b/src/mesh_n_bone/config.py
@@ -29,6 +29,7 @@ def read_multires_config(config_path):
         - ``aggressiveness``: ``7``
         - ``delete_decimated_meshes``: ``False``
         - ``roi``: ``None``
+        - ``target_faces_per_lod0_chunk``: ``25000``
 
         *optional_properties_settings* defaults:
 
@@ -60,6 +61,13 @@ def read_multires_config(config_path):
             optional_decimation_settings["delete_decimated_meshes"] = False
         if "roi" not in optional_decimation_settings:
             optional_decimation_settings["roi"] = None
+        if "target_faces_per_lod0_chunk" not in optional_decimation_settings:
+            from mesh_n_bone.multires.multires import (
+                DEFAULT_TARGET_FACES_PER_LOD0_CHUNK,
+            )
+            optional_decimation_settings["target_faces_per_lod0_chunk"] = (
+                DEFAULT_TARGET_FACES_PER_LOD0_CHUNK
+            )
 
         optional_properties_settings = config.get("optional_properties_settings", {})
         if "segment_properties_csv" not in optional_properties_settings:

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -14,7 +14,13 @@ import json
 import pymeshlab
 from mesh_n_bone.util import dask_util
 from mesh_n_bone.util.logging import Timing_Messager
-from mesh_n_bone.util.zarr_io import open_dataset, split_dataset_path, read_raw_voxel_size, _read_attrs
+from mesh_n_bone.util.zarr_io import (
+    open_dataset,
+    split_dataset_path,
+    read_raw_voxel_size,
+    _read_attrs,
+    _get_multiscales,
+)
 from mesh_n_bone.util.image_data_interface import open_ds_tensorstore, to_ndarray_tensorstore
 from mesh_n_bone.meshify.downsample import (
     downsample_labels_3d_suppress_zero,
@@ -66,7 +72,7 @@ def _read_ome_ngff_transform(input_path):
             parent_dir = zarr_root_path
 
         parent_attrs = _read_attrs(parent_dir)
-        multiscales = parent_attrs.get("multiscales")
+        multiscales = _get_multiscales(parent_attrs)
         if not multiscales:
             return None, None, None
 

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -20,6 +20,7 @@ from mesh_n_bone.util.zarr_io import (
     read_raw_voxel_size,
     _read_attrs,
     _get_multiscales,
+    _extract_ome_scale_translation,
 )
 from mesh_n_bone.util.image_data_interface import open_ds_tensorstore, to_ndarray_tensorstore
 from mesh_n_bone.meshify.downsample import (
@@ -44,13 +45,17 @@ _OME_UNIT_TO_ABBREVIATION = {
 def _read_ome_ngff_transform(input_path):
     """Extract voxel_size, offset, and coordinate unit from OME-NGFF metadata.
 
-    Looks at the parent group's .zattrs for coordinateTransformations
-    that apply to the dataset at input_path. Returns
-    (voxel_size, offset, coordinate_units) in ZYX order,
-    or (None, None, None) if not found.
+    Reads multiscales from the parent group of *input_path*. Robust to
+    OME-Zarr v0.4 / v0.5 layouts, non-ZYX axes, root-level
+    coordinateTransformations, and arbitrary dataset paths — all via
+    :func:`mesh_n_bone.util.zarr_io._extract_ome_scale_translation`.
+
+    Returns ``(voxel_size, offset, coordinate_units)`` in ZYX order
+    (or ``(None, None, None)`` when no metadata is found). The voxel
+    size and offset are returned as ``np.ndarray`` for consistency
+    with existing callers.
     """
-    # Find the zarr/n5 root and dataset path within it
-    for ext in [".zarr", ".n5"]:
+    for ext in (".zarr", ".n5"):
         if ext in input_path:
             parts = input_path.split(ext + "/")
             zarr_root_path = parts[0] + ext
@@ -59,51 +64,38 @@ def _read_ome_ngff_transform(input_path):
     else:
         return None, None, None
 
-    # The dataset name is the last component (e.g. "s0" from "cell/s0")
     dataset_name = os.path.basename(dataset_path)
-    # The parent group path (e.g. "cell" from "cell/s0")
     parent_path = os.path.dirname(dataset_path)
+    parent_dir = os.path.join(zarr_root_path, parent_path) if parent_path else zarr_root_path
 
     try:
-        # Read parent group attributes directly from JSON metadata files
-        if parent_path:
-            parent_dir = os.path.join(zarr_root_path, parent_path)
-        else:
-            parent_dir = zarr_root_path
-
         parent_attrs = _read_attrs(parent_dir)
         multiscales = _get_multiscales(parent_attrs)
         if not multiscales:
             return None, None, None
 
-        for ms in multiscales:
-            # Extract coordinate unit from axes metadata
-            coordinate_units = None
-            axes = ms.get("axes", [])
-            for ax in axes:
-                if ax.get("type") == "space":
-                    unit = ax.get("unit")
-                    if unit is not None:
-                        coordinate_units = _OME_UNIT_TO_ABBREVIATION.get(
-                            unit, unit
-                        )
-                    break
+        scale, translation = _extract_ome_scale_translation(
+            parent_attrs, dataset_name=dataset_name,
+        )
+        if scale is None and translation is None:
+            return None, None, None
 
-            for ds_info in ms.get("datasets", []):
-                if ds_info.get("path") == dataset_name:
-                    transforms = ds_info.get("coordinateTransformations", [])
-                    voxel_size = None
-                    offset = None
-                    for t in transforms:
-                        if t.get("type") == "scale":
-                            voxel_size = np.array(t["scale"], dtype=float)
-                        elif t.get("type") == "translation":
-                            offset = np.array(t["translation"], dtype=float)
-                    return voxel_size, offset, coordinate_units
+        # Pull the unit off the first spatial axis (units are per-axis but
+        # mesh-n-bone treats voxel_size isotropically here).
+        coordinate_units = None
+        for ax in multiscales[0].get("axes", []) or []:
+            if isinstance(ax, dict) and ax.get("type") == "space":
+                unit = ax.get("unit")
+                if unit is not None:
+                    coordinate_units = _OME_UNIT_TO_ABBREVIATION.get(unit, unit)
+                break
+
+        voxel_size = np.array(scale, dtype=float) if scale is not None else None
+        offset = np.array(translation, dtype=float) if translation is not None else None
+        return voxel_size, offset, coordinate_units
     except Exception as e:
         logger.debug(f"Could not read OME-NGFF metadata: {e}")
-
-    return None, None, None
+        return None, None, None
 
 
 try:

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -388,6 +388,7 @@ class Meshify:
         do_multires: bool = False,
         num_lods: int = 3,
         lod_0_box_size=None,
+        target_faces_per_lod0_chunk: int = 25_000,
         downsample_method: str = "mode_suppress_zero",
         multires_strategy: str = "decimate",
         decimation_factor: int = 4,
@@ -527,6 +528,7 @@ class Meshify:
                 self.lod_0_box_size = np.repeat(self.lod_0_box_size, 3)
         else:
             self.lod_0_box_size = None
+        self.target_faces_per_lod0_chunk = target_faces_per_lod0_chunk
         self.downsample_method = downsample_method
         self.input_path = input_path
         self.multires_strategy = multires_strategy
@@ -1247,6 +1249,7 @@ class Meshify:
                     mesh_ext,
                     np.array(file_sizes, dtype=float),
                     self.lod_0_box_size,
+                    target_faces_per_lod0_chunk=self.target_faces_per_lod0_chunk,
                 )
 
         with Timing_Messager("Writing info and segment properties files", logger):

--- a/src/mesh_n_bone/multires/multires.py
+++ b/src/mesh_n_bone/multires/multires.py
@@ -19,9 +19,13 @@ from mesh_n_bone.config import read_multires_config
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_TARGET_FACES_PER_LOD0_CHUNK = 25_000
+
+
 def generate_neuroglancer_multires_mesh(
     id, num_subtask_workers, output_path, lods, original_ext, lod_0_box_size=None,
     vertex_quantization_bits=16,
+    target_faces_per_lod0_chunk=DEFAULT_TARGET_FACES_PER_LOD0_CHUNK,
 ):
     """Create a complete multiresolution mesh for a single segment.
 
@@ -43,7 +47,15 @@ def generate_neuroglancer_multires_mesh(
         File extension of LOD 0 meshes (e.g. ``".ply"``).
     lod_0_box_size : ndarray of float or None
         Chunk box size for LOD 0. If ``None``, computed from mesh
-        bounding box targeting ~25k faces per chunk.
+        bounding box targeting ``target_faces_per_lod0_chunk`` faces
+        per chunk.
+    target_faces_per_lod0_chunk : int
+        Target face count per LOD-0 fragment used by the
+        auto-sizing heuristic. Lower values produce more, smaller
+        chunks (and force multi-LOD output for smaller meshes);
+        higher values keep small meshes in a single fragment so
+        they collapse to 1 LOD. Ignored when *lod_0_box_size* is
+        passed explicitly.
     """
     with ExitStack() as stack:
         if num_subtask_workers > 1:
@@ -80,10 +92,11 @@ def generate_neuroglancer_multires_mesh(
                 distances_per_axis = np.ceil(
                     vertices.max(axis=0) - vertices.min(axis=0)
                 )
-                # Target ~25k faces per LOD 0 fragment (~30 KB Draco-
-                # compressed at 10-bit quantization).  This balances
-                # spatial selectivity against HTTP per-request overhead.
-                heuristic_num_chunks = np.ceil(num_faces / 25_000)
+                # Target ``target_faces_per_lod0_chunk`` faces per LOD-0
+                # fragment (default 25k ≈ 30 KB Draco-compressed at
+                # 10-bit quantization).  This balances spatial
+                # selectivity against HTTP per-request overhead.
+                heuristic_num_chunks = np.ceil(num_faces / target_faces_per_lod0_chunk)
                 if heuristic_num_chunks == 1:
                     lod_0_box_size = distances_per_axis + 1
                 else:
@@ -261,6 +274,7 @@ def _mesh_intersects_roi(mesh_path, roi_begin, roi_end):
 def generate_all_neuroglancer_multires_meshes(
     output_path, num_workers, ids, lods, original_ext, file_sizes,
     lod_0_box_size=None, vertex_quantization_bits=16,
+    target_faces_per_lod0_chunk=DEFAULT_TARGET_FACES_PER_LOD0_CHUNK,
 ):
     """Generate Neuroglancer multiresolution meshes for all segments.
 
@@ -283,6 +297,8 @@ def generate_all_neuroglancer_multires_meshes(
         File sizes of LOD 0 meshes (used for work balancing).
     lod_0_box_size : ndarray of float or None
         Chunk box size for LOD 0. ``None`` for auto-computation.
+    target_faces_per_lod0_chunk : int
+        Forwarded to :func:`generate_neuroglancer_multires_mesh`.
     """
 
     def get_number_of_subtask_workers(file_sizes, num_workers):
@@ -293,7 +309,10 @@ def generate_all_neuroglancer_multires_meshes(
 
     num_subtask_workers = get_number_of_subtask_workers(file_sizes, num_workers)
     variable_args_list = []
-    fixed_args_list = [output_path, lods, original_ext, lod_0_box_size, vertex_quantization_bits]
+    fixed_args_list = [
+        output_path, lods, original_ext, lod_0_box_size,
+        vertex_quantization_bits, target_faces_per_lod0_chunk,
+    ]
     for idx, id in enumerate(ids):
         variable_args_list.append((id, num_subtask_workers[idx]))
     dask_util.compute_bag(
@@ -336,6 +355,7 @@ def run_multires(config_path, num_workers, roi=None):
     decimation_factor = optional_decimation_settings["decimation_factor"]
     aggressiveness = optional_decimation_settings["aggressiveness"]
     delete_decimated_meshes_flag = optional_decimation_settings["delete_decimated_meshes"]
+    target_faces_per_lod0_chunk = optional_decimation_settings["target_faces_per_lod0_chunk"]
 
     segment_properties_csv = optional_properties_settings["segment_properties_csv"]
     segment_properties_columns = optional_properties_settings["segment_properties_columns"]
@@ -416,6 +436,7 @@ def run_multires(config_path, num_workers, roi=None):
                         output_path, num_workers, mesh_ids, lods, mesh_ext,
                         np.array(file_sizes), lod_0_box_size,
                         vertex_quantization_bits=16,
+                        target_faces_per_lod0_chunk=target_faces_per_lod0_chunk,
                     )
 
             with Timing_Messager("Writing info and segment properties files", logger):

--- a/src/mesh_n_bone/util/zarr_io.py
+++ b/src/mesh_n_bone/util/zarr_io.py
@@ -144,26 +144,38 @@ def open_dataset(filename, ds_name, mode="r"):
         chunks = chunks[::-1]
 
     data = ArrayMetadata(shape, dtype, chunks, attrs)
-    voxel_size, offset = _read_voxel_size_offset(data)
+    parent_dir = os.path.dirname(full_path)
+    parent_attrs = _read_attrs(parent_dir) if parent_dir and parent_dir != full_path else None
+    voxel_size, offset = _read_voxel_size_offset(data, parent_attrs=parent_attrs)
     return CellMapArray(data, voxel_size, offset, dataset_path=full_path)
 
 
-def _read_voxel_size_offset(data):
+def _read_voxel_size_offset(data, parent_attrs=None):
     """Read voxel_size and offset from array attributes.
 
-    Checks funlib-style, N5, and OME-Zarr metadata formats.
+    Checks funlib-style, N5, and OME-Zarr metadata formats. When the
+    array itself carries no resolution/offset, falls back to OME-Zarr
+    multiscales on the parent group (both v0.4 top-level layout and
+    v0.5 ``ome``-namespaced layout).
 
     Parameters
     ----------
     data : ArrayMetadata
         Metadata container with ``.attrs`` dict.
+    parent_attrs : dict, optional
+        Attributes of the parent group (used for OME multiscales
+        fallback). Pass ``None`` to skip the fallback.
 
     Returns
     -------
     tuple[Coordinate, Coordinate]
-        ``(voxel_size, offset)``
+        ``(voxel_size, offset)``. Values are truncated to int via
+        funlib ``Coordinate``; for non-integer voxel sizes use
+        :func:`read_raw_voxel_size` instead.
     """
     attrs = data.attrs
+    voxel_size = None
+    offset = None
 
     if "resolution" in attrs:
         voxel_size = Coordinate(int(v) for v in attrs["resolution"])
@@ -180,12 +192,20 @@ def _read_voxel_size_offset(data):
         else:
             dims = list(attrs["pixelResolution"]["dimensions"])
             voxel_size = Coordinate(int(round(v)) for v in reversed(dims))
-    else:
-        voxel_size = Coordinate(1 for _ in data.shape)
 
     if "offset" in attrs:
         offset = Coordinate(int(v) for v in attrs["offset"])
-    else:
+
+    if (voxel_size is None or offset is None) and parent_attrs:
+        ome_scale, ome_translation = _extract_ome_scale_translation(parent_attrs)
+        if voxel_size is None and ome_scale is not None:
+            voxel_size = Coordinate(int(round(v)) for v in ome_scale)
+        if offset is None and ome_translation is not None:
+            offset = Coordinate(int(round(v)) for v in ome_translation)
+
+    if voxel_size is None:
+        voxel_size = Coordinate(1 for _ in data.shape)
+    if offset is None:
         offset = Coordinate(0 for _ in voxel_size)
 
     return voxel_size, offset
@@ -224,19 +244,49 @@ def read_raw_voxel_size(ds):
 
     # Check OME-Zarr multiscales on parent group
     parent_attrs = _read_parent_attrs(ds)
-    if parent_attrs and "multiscales" in parent_attrs:
-        return _extract_ome_scale(parent_attrs)
+    if parent_attrs is not None:
+        scale, _ = _extract_ome_scale_translation(parent_attrs)
+        if scale is not None:
+            return tuple(float(v) for v in scale)
 
     return tuple(float(v) for v in ds.voxel_size)
 
 
-def _extract_ome_scale(attrs):
-    """Extract voxel size from OME-Zarr multiscales metadata."""
-    transforms = attrs["multiscales"][0]["datasets"][0]["coordinateTransformations"]
+def _get_multiscales(attrs):
+    """Return the OME-Zarr ``multiscales`` list, or ``None``.
+
+    Handles OME-Zarr v0.4 (top-level ``multiscales``) and v0.5
+    (``ome.multiscales``). Returns ``None`` if neither is present.
+    """
+    if not attrs:
+        return None
+    if "multiscales" in attrs:
+        return attrs["multiscales"]
+    ome = attrs.get("ome")
+    if isinstance(ome, dict) and "multiscales" in ome:
+        return ome["multiscales"]
+    return None
+
+
+def _extract_ome_scale_translation(attrs):
+    """Extract scale and translation from OME-Zarr multiscales metadata.
+
+    Reads the first dataset's ``coordinateTransformations``. Returns
+    ``(scale, translation)`` as float tuples; either may be ``None``
+    if absent.
+    """
+    multiscales = _get_multiscales(attrs)
+    if not multiscales:
+        return None, None
+    transforms = multiscales[0]["datasets"][0].get("coordinateTransformations", [])
+    scale = None
+    translation = None
     for t in transforms:
-        if t["type"] == "scale":
-            return tuple(float(v) for v in t["scale"])
-    raise ValueError("No scale transform found in OME-Zarr multiscales metadata")
+        if t.get("type") == "scale":
+            scale = tuple(float(v) for v in t["scale"])
+        elif t.get("type") == "translation":
+            translation = tuple(float(v) for v in t["translation"])
+    return scale, translation
 
 
 def _read_parent_attrs(ds):

--- a/src/mesh_n_bone/util/zarr_io.py
+++ b/src/mesh_n_bone/util/zarr_io.py
@@ -146,109 +146,117 @@ def open_dataset(filename, ds_name, mode="r"):
     data = ArrayMetadata(shape, dtype, chunks, attrs)
     parent_dir = os.path.dirname(full_path)
     parent_attrs = _read_attrs(parent_dir) if parent_dir and parent_dir != full_path else None
-    voxel_size, offset = _read_voxel_size_offset(data, parent_attrs=parent_attrs)
+    dataset_name = os.path.basename(full_path) or None
+    voxel_size, offset = _read_voxel_size_offset(
+        data, parent_attrs=parent_attrs, dataset_name=dataset_name,
+    )
     return CellMapArray(data, voxel_size, offset, dataset_path=full_path)
 
 
-def _read_voxel_size_offset(data, parent_attrs=None):
-    """Read voxel_size and offset from array attributes.
+def _read_funlib_voxel_offset(attrs):
+    """Pull funlib/N5-style ``voxel_size`` and ``offset`` from a single attrs dict.
 
-    Checks funlib-style, N5, and OME-Zarr metadata formats. When the
-    array itself carries no resolution/offset, falls back to OME-Zarr
-    multiscales on the parent group (both v0.4 top-level layout and
-    v0.5 ``ome``-namespaced layout).
-
-    Parameters
-    ----------
-    data : ArrayMetadata
-        Metadata container with ``.attrs`` dict.
-    parent_attrs : dict, optional
-        Attributes of the parent group (used for OME multiscales
-        fallback). Pass ``None`` to skip the fallback.
-
-    Returns
-    -------
-    tuple[Coordinate, Coordinate]
-        ``(voxel_size, offset)``. Values are truncated to int via
-        funlib ``Coordinate``; for non-integer voxel sizes use
-        :func:`read_raw_voxel_size` instead.
+    Returns ``(voxel_size, offset)`` as float lists, with each component
+    ``None`` when not declared. Combined into one helper so both the
+    array attrs and the parent-group attrs can use the same lookup.
     """
-    attrs = data.attrs
+    if not attrs:
+        return None, None
     voxel_size = None
-    offset = None
-
     if "resolution" in attrs:
-        voxel_size = Coordinate(int(v) for v in attrs["resolution"])
+        voxel_size = [float(v) for v in attrs["resolution"]]
     elif "voxel_size" in attrs:
-        voxel_size = Coordinate(int(v) for v in attrs["voxel_size"])
+        voxel_size = [float(v) for v in attrs["voxel_size"]]
     elif "pixelResolution" in attrs:
-        # N5 pixelResolution.dimensions is in XYZ order, but funlib
-        # Coordinates are ZYX.  Prefer transform.scale (already ZYX
-        # via transform.axes) when available; otherwise reverse
-        # pixelResolution.
+        # N5 pixelResolution.dimensions is XYZ; funlib expects ZYX.
+        # Prefer transform.scale (already ZYX via transform.axes).
         transform = attrs.get("transform", {})
         if "scale" in transform:
-            voxel_size = Coordinate(int(round(v)) for v in transform["scale"])
+            voxel_size = [float(v) for v in transform["scale"]]
         else:
             dims = list(attrs["pixelResolution"]["dimensions"])
-            voxel_size = Coordinate(int(round(v)) for v in reversed(dims))
+            voxel_size = [float(v) for v in reversed(dims)]
 
-    if "offset" in attrs:
-        offset = Coordinate(int(v) for v in attrs["offset"])
+    offset = [float(v) for v in attrs["offset"]] if "offset" in attrs else None
+    return voxel_size, offset
+
+
+def _resolve_voxel_size_offset(attrs, parent_attrs, dataset_name):
+    """Resolve voxel_size and offset as float lists from any supported source.
+
+    Checks, in order: (1) the array's own attrs (funlib/N5 keys),
+    (2) the parent group's attrs (same funlib/N5 keys — used by some
+    N5 multiscales setups that put resolution at the group level),
+    (3) OME-Zarr multiscales on the parent group (v0.4 + v0.5,
+    arbitrary axis order, root-level coordinateTransformations,
+    arbitrary dataset path).
+
+    Either component may come back ``None`` if no source declared it.
+    """
+    voxel_size, offset = _read_funlib_voxel_offset(attrs)
 
     if (voxel_size is None or offset is None) and parent_attrs:
-        ome_scale, ome_translation = _extract_ome_scale_translation(parent_attrs)
-        if voxel_size is None and ome_scale is not None:
-            voxel_size = Coordinate(int(round(v)) for v in ome_scale)
-        if offset is None and ome_translation is not None:
-            offset = Coordinate(int(round(v)) for v in ome_translation)
+        p_voxel, p_offset = _read_funlib_voxel_offset(parent_attrs)
+        if voxel_size is None:
+            voxel_size = p_voxel
+        if offset is None:
+            offset = p_offset
 
-    if voxel_size is None:
-        voxel_size = Coordinate(1 for _ in data.shape)
-    if offset is None:
-        offset = Coordinate(0 for _ in voxel_size)
+    if (voxel_size is None or offset is None) and parent_attrs:
+        ome_scale, ome_translation = _extract_ome_scale_translation(
+            parent_attrs, dataset_name=dataset_name,
+        )
+        if voxel_size is None and ome_scale is not None:
+            voxel_size = list(ome_scale)
+        if offset is None and ome_translation is not None:
+            offset = list(ome_translation)
 
     return voxel_size, offset
 
 
-def read_raw_voxel_size(ds):
-    """Read the original float voxel_size from dataset attributes.
+def _read_voxel_size_offset(data, parent_attrs=None, dataset_name=None):
+    """Read voxel_size and offset and return them as funlib ``Coordinate``s.
 
-    Unlike ``_read_voxel_size_offset``, preserves float precision
-    (funlib.geometry.Coordinate truncates to int).
-
-    Parameters
-    ----------
-    ds : CellMapArray
-        Dataset wrapper.
-
-    Returns
-    -------
-    tuple[float, ...]
-        True voxel size as floats.
+    Composes ``_resolve_voxel_size_offset`` and casts to int; logs a
+    warning if non-integer voxel sizes are silently rounded so callers
+    needing float precision use :func:`read_raw_voxel_size` instead.
     """
-    attrs = ds.data.attrs
+    voxel_size, offset = _resolve_voxel_size_offset(
+        data.attrs, parent_attrs, dataset_name,
+    )
 
-    if "voxel_size" in attrs:
-        return tuple(float(v) for v in attrs["voxel_size"])
+    if voxel_size is not None and any(v != int(v) for v in voxel_size):
+        logger.warning(
+            "Rounding non-integer voxel_size %s to integers for "
+            "Coordinate; use read_raw_voxel_size for float-precision access.",
+            voxel_size,
+        )
 
-    if "resolution" in attrs:
-        return tuple(float(v) for v in attrs["resolution"])
+    if voxel_size is None:
+        voxel_size = [1] * len(data.shape)
+    if offset is None:
+        offset = [0] * len(voxel_size)
 
-    if "pixelResolution" in attrs:
-        transform = attrs.get("transform", {})
-        if "scale" in transform:
-            return tuple(float(v) for v in transform["scale"])
-        dims = list(attrs["pixelResolution"]["dimensions"])
-        return tuple(float(v) for v in reversed(dims))
+    return (
+        Coordinate(int(round(v)) for v in voxel_size),
+        Coordinate(int(round(v)) for v in offset),
+    )
 
-    # Check OME-Zarr multiscales on parent group
+
+def read_raw_voxel_size(ds):
+    """Return the float voxel_size, preserving non-integer precision.
+
+    Same source-resolution as :func:`_read_voxel_size_offset` but does
+    not round. Falls back to ``ds.voxel_size`` (already a Coordinate)
+    when no metadata source declares a value.
+    """
     parent_attrs = _read_parent_attrs(ds)
-    if parent_attrs is not None:
-        scale, _ = _extract_ome_scale_translation(parent_attrs)
-        if scale is not None:
-            return tuple(float(v) for v in scale)
-
+    dataset_name = os.path.basename(getattr(ds, "_dataset_path", "")) or None
+    voxel_size, _ = _resolve_voxel_size_offset(
+        ds.data.attrs, parent_attrs, dataset_name,
+    )
+    if voxel_size is not None:
+        return tuple(float(v) for v in voxel_size)
     return tuple(float(v) for v in ds.voxel_size)
 
 
@@ -256,37 +264,205 @@ def _get_multiscales(attrs):
     """Return the OME-Zarr ``multiscales`` list, or ``None``.
 
     Handles OME-Zarr v0.4 (top-level ``multiscales``) and v0.5
-    (``ome.multiscales``). Returns ``None`` if neither is present.
+    (``ome.multiscales``). Logs a warning and returns ``None`` if an
+    ``ome`` block is present but does not contain ``multiscales``,
+    which usually means the spec has moved on to a layout this
+    helper does not recognise yet.
     """
     if not attrs:
         return None
     if "multiscales" in attrs:
         return attrs["multiscales"]
     ome = attrs.get("ome")
-    if isinstance(ome, dict) and "multiscales" in ome:
-        return ome["multiscales"]
+    if isinstance(ome, dict):
+        if "multiscales" in ome:
+            return ome["multiscales"]
+        logger.warning(
+            "OME-Zarr 'ome' attribute block present but no 'multiscales' "
+            "found inside it (keys=%s). Falling back to default voxel size; "
+            "this likely means a newer OME-Zarr spec layout the helper "
+            "needs to be updated for.",
+            sorted(ome.keys()),
+        )
     return None
 
 
-def _extract_ome_scale_translation(attrs):
-    """Extract scale and translation from OME-Zarr multiscales metadata.
+def _read_transforms(transforms):
+    """Compose a coordinateTransformations list in document order.
 
-    Reads the first dataset's ``coordinateTransformations``. Returns
-    ``(scale, translation)`` as float tuples; either may be ``None``
-    if absent.
+    OME-Zarr applies transformations left-to-right, so ``[scale,
+    translation]`` differs from ``[translation, scale]``. This helper
+    accumulates the equivalent affine ``(scale, translation)`` such
+    that ``physical = scale * voxel + translation``, regardless of
+    order. Unknown types (e.g. ``identity``) are ignored.
+
+    Returns ``(scale, translation)`` as ``list[float] | None``.
+    """
+    s_acc = None
+    t_acc = None
+    for entry in transforms or []:
+        if not isinstance(entry, dict):
+            continue
+        ttype = entry.get("type")
+        if ttype == "scale" and "scale" in entry:
+            s = [float(v) for v in entry["scale"]]
+            if s_acc is None:
+                s_acc = list(s)
+            else:
+                s_acc = [s_acc[i] * s[i] for i in range(len(s))]
+            if t_acc is not None:
+                t_acc = [t_acc[i] * s[i] for i in range(len(s))]
+        elif ttype == "translation" and "translation" in entry:
+            t = [float(v) for v in entry["translation"]]
+            if t_acc is None:
+                t_acc = list(t)
+            else:
+                t_acc = [t_acc[i] + t[i] for i in range(len(t))]
+    return s_acc, t_acc
+
+
+def _compose_transforms(scale_d, trans_d, scale_r, trans_r):
+    """Compose dataset-level then root-level transforms.
+
+    OME-Zarr applies coordinateTransformations in document order; the
+    multiscales root-level list applies on top of the per-dataset list.
+
+    Going from voxel coords ``v`` to physical coords::
+
+        physical = trans_r + scale_r * (trans_d + scale_d * v)
+                 = (trans_r + scale_r * trans_d) + (scale_r * scale_d) * v
+
+    Missing components default to scale=1, translation=0. Returns the
+    composed ``(scale, translation)`` as ``list[float] | None``.
+    """
+    if scale_r is None and trans_r is None:
+        return scale_d, trans_d
+
+    n = None
+    for vec in (scale_d, trans_d, scale_r, trans_r):
+        if vec is not None:
+            n = len(vec)
+            break
+    if n is None:
+        return None, None
+
+    s_d = [float(v) for v in scale_d] if scale_d else [1.0] * n
+    t_d = [float(v) for v in trans_d] if trans_d else [0.0] * n
+    s_r = [float(v) for v in scale_r] if scale_r else [1.0] * n
+    t_r = [float(v) for v in trans_r] if trans_r else [0.0] * n
+
+    composed_scale = [s_r[i] * s_d[i] for i in range(n)]
+    composed_trans = [t_r[i] + s_r[i] * t_d[i] for i in range(n)]
+    return composed_scale, composed_trans
+
+
+def _spatial_permutation(axes):
+    """Return indices that select spatial axes in ZYX order.
+
+    Falls back to ``None`` (caller should treat the array as already
+    ZYX) when the axes list is missing, has no per-axis ``type``
+    metadata, or doesn't use the canonical x/y/z names.
+
+    This lets OME datasets with ``axes=[t, c, z, y, x]`` (5D) or
+    ``axes=[x, y, z]`` (XYZ) be read correctly from a 3D mesh-n-bone
+    pipeline.
+    """
+    if not axes:
+        return None
+
+    space_indices = []
+    space_names = []
+    for i, ax in enumerate(axes):
+        if not isinstance(ax, dict):
+            continue
+        ax_type = ax.get("type", "space")
+        if ax_type == "space":
+            space_indices.append(i)
+            space_names.append(str(ax.get("name", "")).lower())
+
+    if not space_indices:
+        return None
+
+    if set(space_names) >= {"x", "y", "z"} and len(space_names) >= 3:
+        ordered = []
+        for target in ("z", "y", "x"):
+            ordered.append(space_indices[space_names.index(target)])
+        return ordered
+
+    return space_indices
+
+
+def _apply_permutation(values, permutation):
+    """Reorder *values* by *permutation*; return a tuple of floats."""
+    if values is None:
+        return None
+    if permutation is None:
+        return tuple(float(v) for v in values)
+    return tuple(float(values[i]) for i in permutation)
+
+
+def _select_dataset(datasets, dataset_name):
+    """Pick the multiscales dataset entry matching *dataset_name*.
+
+    Falls back to the first entry when *dataset_name* is None or when
+    no entry has a matching ``path``. Returns ``None`` if there are no
+    datasets.
+    """
+    if not datasets:
+        return None
+    if dataset_name is not None:
+        for d in datasets:
+            if isinstance(d, dict) and d.get("path") == dataset_name:
+                return d
+    return datasets[0]
+
+
+def _extract_ome_scale_translation(attrs, dataset_name=None):
+    """Read scale and translation from OME-Zarr multiscales metadata.
+
+    Robust to:
+      * v0.4 top-level ``multiscales`` and v0.5 ``ome.multiscales``,
+      * ``s0`` not being the first dataset (matches by ``path``),
+      * root-level ``coordinateTransformations`` (composed with the
+        per-dataset transforms),
+      * non-ZYX axis ordering and 4D/5D axes lists with non-spatial
+        dimensions (axes are filtered to ``type=="space"`` and reordered
+        to ZYX when named ``x``/``y``/``z``).
+
+    Parameters
+    ----------
+    attrs : dict
+        Group attributes containing multiscales metadata.
+    dataset_name : str, optional
+        ``path`` of the dataset to match (e.g. ``"s0"``). When omitted,
+        the first dataset entry is used.
+
+    Returns
+    -------
+    tuple
+        ``(scale, translation)`` as float tuples in ZYX order, or
+        ``(None, None)`` if no multiscales metadata is found. Either
+        component may be ``None`` if the corresponding transform was
+        not declared.
     """
     multiscales = _get_multiscales(attrs)
     if not multiscales:
         return None, None
-    transforms = multiscales[0]["datasets"][0].get("coordinateTransformations", [])
-    scale = None
-    translation = None
-    for t in transforms:
-        if t.get("type") == "scale":
-            scale = tuple(float(v) for v in t["scale"])
-        elif t.get("type") == "translation":
-            translation = tuple(float(v) for v in t["translation"])
-    return scale, translation
+
+    ms = multiscales[0] if isinstance(multiscales, list) and multiscales else None
+    if not isinstance(ms, dict):
+        return None, None
+
+    chosen = _select_dataset(ms.get("datasets", []), dataset_name)
+    if chosen is None:
+        return None, None
+
+    scale_d, trans_d = _read_transforms(chosen.get("coordinateTransformations", []))
+    scale_r, trans_r = _read_transforms(ms.get("coordinateTransformations", []))
+    scale, translation = _compose_transforms(scale_d, trans_d, scale_r, trans_r)
+
+    perm = _spatial_permutation(ms.get("axes", []))
+    return _apply_permutation(scale, perm), _apply_permutation(translation, perm)
 
 
 def _read_parent_attrs(ds):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,10 +216,17 @@ def zarr_sphere(tmp_output_dir):
 
 
 def _make_zarr_cube_ome_ngff(tmp_dir, voxel_size, offset, vol_shape, cube_slice,
-                              label=1, chunk_shape=None):
+                              label=1, chunk_shape=None, ome_version="0.4"):
     """Like _make_zarr_cube but stores metadata in OME-NGFF multiscales format
     (parent .zattrs) instead of per-dataset .zattrs. This mimics how most
-    cellmap/OME-Zarr datasets store their coordinate transforms."""
+    cellmap/OME-Zarr datasets store their coordinate transforms.
+
+    ome_version selects the spec layout:
+      - "0.4": multiscales placed directly on the parent group's attrs
+        (legacy / cellmap convention).
+      - "0.5": multiscales nested under an ``ome`` key on the parent
+        group's attrs (paintera v0.5 convention).
+    """
     if chunk_shape is None:
         chunk_shape = vol_shape
     zarr_path = os.path.join(tmp_dir, "ome.zarr")
@@ -228,9 +235,7 @@ def _make_zarr_cube_ome_ngff(tmp_dir, voxel_size, offset, vol_shape, cube_slice,
     vol[cube_slice] = label
     root.create_array("seg/s0", data=vol, chunks=chunk_shape)
 
-    # Write OME-NGFF multiscales metadata on the PARENT group
-    seg_group = root["seg"]
-    seg_group.attrs["multiscales"] = [{
+    multiscales = [{
         "axes": [
             {"name": "z", "type": "space", "unit": "nanometer"},
             {"name": "y", "type": "space", "unit": "nanometer"},
@@ -243,10 +248,16 @@ def _make_zarr_cube_ome_ngff(tmp_dir, voxel_size, offset, vol_shape, cube_slice,
             ],
             "path": "s0",
         }],
-        "version": "0.4",
+        "version": ome_version,
     }]
 
-    # NO attrs on the dataset itself — open_dataset will see voxel_size=(1,1,1)
+    seg_group = root["seg"]
+    if ome_version == "0.5":
+        seg_group.attrs["ome"] = {"multiscales": multiscales, "version": "0.5"}
+    else:
+        seg_group.attrs["multiscales"] = multiscales
+
+    # NO attrs on the dataset itself — open_dataset must traverse to parent.
 
     vs = np.array(voxel_size, dtype=float)
     off = np.array(offset, dtype=float)
@@ -266,7 +277,7 @@ def _make_zarr_cube_ome_ngff(tmp_dir, voxel_size, offset, vol_shape, cube_slice,
 
 @pytest.fixture
 def zarr_cube_ome_ngff(tmp_output_dir):
-    """Zarr volume with OME-NGFF multiscales metadata (no per-dataset .zattrs).
+    """Zarr volume with OME-NGFF v0.4 multiscales metadata (no per-dataset .zattrs).
 
     Volume: 64x64x64, voxel_size=[8,8,8], offset=[100,100,100] (ZYX).
     Cube: label 1 at voxels [8:48, 8:48, 8:48].
@@ -279,4 +290,23 @@ def zarr_cube_ome_ngff(tmp_output_dir):
         vol_shape=(64, 64, 64),
         cube_slice=(slice(8, 48), slice(8, 48), slice(8, 48)),
         chunk_shape=(16, 16, 16),
+        ome_version="0.4",
+    )
+
+
+@pytest.fixture
+def zarr_cube_ome_ngff_v05(tmp_output_dir):
+    """Zarr volume with OME-NGFF v0.5 (``ome.multiscales``) metadata.
+
+    Mirrors ``zarr_cube_ome_ngff`` but stores multiscales under the
+    ``ome`` namespace, matching the paintera v0.5 convention.
+    """
+    return _make_zarr_cube_ome_ngff(
+        tmp_output_dir,
+        voxel_size=[8, 8, 8],
+        offset=[100, 100, 100],
+        vol_shape=(64, 64, 64),
+        cube_slice=(slice(8, 48), slice(8, 48), slice(8, 48)),
+        chunk_shape=(16, 16, 16),
+        ome_version="0.5",
     )

--- a/tests/test_integration_coordinates.py
+++ b/tests/test_integration_coordinates.py
@@ -151,6 +151,22 @@ class TestOmeNgffCoordinates:
             f"voxel_size may not have been applied"
         )
 
+    def test_ome_ngff_v05_cube_bounds(self, zarr_cube_ome_ngff_v05, tmp_output_dir):
+        """Same as v0.4 test but with multiscales nested under ``ome`` (v0.5)."""
+        zarr_path, expected_min, expected_max, expected_center = zarr_cube_ome_ngff_v05
+        output_dir = os.path.join(tmp_output_dir, "ome_v05_cube")
+        _run_meshify(zarr_path, output_dir)
+
+        mesh = trimesh.load(os.path.join(output_dir, "meshes", "1.ply"))
+
+        voxel_size = 8.0
+        np.testing.assert_allclose(mesh.bounds[0], expected_min, atol=voxel_size,
+                                   err_msg="OME-NGFF v0.5 cube min bounds wrong")
+        np.testing.assert_allclose(mesh.bounds[1], expected_max, atol=voxel_size,
+                                   err_msg="OME-NGFF v0.5 cube max bounds wrong")
+        np.testing.assert_allclose(mesh.centroid, expected_center, atol=voxel_size,
+                                   err_msg="OME-NGFF v0.5 cube centroid wrong")
+
 
 class TestSphereGeometry:
     """Test that a sphere mesh has approximately correct volume and shape."""

--- a/tests/test_integration_multires.py
+++ b/tests/test_integration_multires.py
@@ -449,6 +449,54 @@ class TestLodTruncation:
         assert num_lods == 3, f"Expected 3 LODs, got {num_lods}"
 
 
+class TestTargetFacesPerLod0Chunk:
+    """``target_faces_per_lod0_chunk`` overrides the auto-sizing heuristic.
+
+    The default 25k-faces threshold collapses small meshes (under 25k
+    faces) to a single LOD-0 chunk and therefore a single LOD overall.
+    Lowering the threshold should force a multi-chunk grid and keep
+    additional LODs.
+    """
+
+    def test_low_threshold_keeps_multiple_lods(self, multires_mesh_dir):
+        # ``multires_mesh_dir`` contains an icosphere (subdivisions=3,
+        # 1280 faces at LOD 0) — well below 25k, so the default
+        # heuristic collapses it to 1 LOD even though both LOD files
+        # exist on disk.
+        output_path = multires_mesh_dir
+
+        generate_neuroglancer_multires_mesh(
+            id=1,
+            num_subtask_workers=1,
+            output_path=output_path,
+            lods=[0, 1],
+            original_ext=".ply",
+        )
+        with open(os.path.join(output_path, "multires", "1.index"), "rb") as f:
+            default_num_lods = struct.unpack("<I", f.read()[24:28])[0]
+        assert default_num_lods == 1, (
+            f"Default 25k-face heuristic should collapse a 1280-face mesh "
+            f"to 1 LOD; got {default_num_lods}."
+        )
+
+        # Force the heuristic to chunk by setting the per-chunk target
+        # well below the LOD-0 face count.
+        generate_neuroglancer_multires_mesh(
+            id=1,
+            num_subtask_workers=1,
+            output_path=output_path,
+            lods=[0, 1],
+            original_ext=".ply",
+            target_faces_per_lod0_chunk=100,
+        )
+        with open(os.path.join(output_path, "multires", "1.index"), "rb") as f:
+            tuned_num_lods = struct.unpack("<I", f.read()[24:28])[0]
+        assert tuned_num_lods > default_num_lods, (
+            "Lowering target_faces_per_lod0_chunk should produce more LODs"
+            f" than the default; got {tuned_num_lods} vs {default_num_lods}."
+        )
+
+
 class TestIndexFileFormat:
     """Test the neuroglancer multilod_draco index file format."""
 

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -1,5 +1,6 @@
 """Unit tests for OME-NGFF metadata helpers in mesh_n_bone.util.zarr_io."""
 
+import logging
 import os
 
 import numpy as np
@@ -7,8 +8,11 @@ import pytest
 import zarr
 
 from mesh_n_bone.util.zarr_io import (
+    ArrayMetadata,
     _extract_ome_scale_translation,
     _get_multiscales,
+    _read_funlib_voxel_offset,
+    _read_transforms,
     _read_voxel_size_offset,
     open_dataset,
     read_raw_voxel_size,
@@ -144,42 +148,250 @@ class TestOpenDatasetOmeFallback:
         assert raw == (8.0, 16.0, 32.0)
 
 
+def _empty_meta(attrs=None):
+    return ArrayMetadata(
+        shape=(4, 4, 4), dtype=np.uint32, chunks=(4, 4, 4), attrs=attrs or {},
+    )
+
+
 class TestReadVoxelSizeOffsetParentFallback:
     """The ``parent_attrs`` parameter feeds the OME multiscales fallback."""
 
     def test_array_attrs_take_precedence_over_parent(self):
-        # If the array carries explicit voxel_size, the OME parent fallback
-        # must not override it.
-        from mesh_n_bone.util.zarr_io import ArrayMetadata
-
-        data = ArrayMetadata(
-            shape=(4, 4, 4),
-            dtype=np.uint32,
-            chunks=(4, 4, 4),
-            attrs={"voxel_size": [2, 2, 2], "offset": [1, 1, 1]},
-        )
+        data = _empty_meta({"voxel_size": [2, 2, 2], "offset": [1, 1, 1]})
         parent_attrs = {"multiscales": _multiscales_block([8, 8, 8], [9, 9, 9])}
         vs, off = _read_voxel_size_offset(data, parent_attrs=parent_attrs)
         assert tuple(vs) == (2, 2, 2)
         assert tuple(off) == (1, 1, 1)
 
     def test_parent_fallback_when_array_empty(self):
-        from mesh_n_bone.util.zarr_io import ArrayMetadata
-
-        data = ArrayMetadata(
-            shape=(4, 4, 4), dtype=np.uint32, chunks=(4, 4, 4), attrs={},
-        )
+        data = _empty_meta()
         parent_attrs = {"ome": {"multiscales": _multiscales_block([8, 8, 8], [9, 9, 9])}}
         vs, off = _read_voxel_size_offset(data, parent_attrs=parent_attrs)
         assert tuple(vs) == (8, 8, 8)
         assert tuple(off) == (9, 9, 9)
 
-    def test_no_parent_attrs_falls_back_to_unit(self):
-        from mesh_n_bone.util.zarr_io import ArrayMetadata
+    def test_parent_funlib_fallback(self):
+        # #7: some N5 multiscales setups put resolution on the parent
+        # group instead of each scale array.
+        data = _empty_meta()
+        parent_attrs = {"voxel_size": [16, 16, 16], "offset": [4, 4, 4]}
+        vs, off = _read_voxel_size_offset(data, parent_attrs=parent_attrs)
+        assert tuple(vs) == (16, 16, 16)
+        assert tuple(off) == (4, 4, 4)
 
-        data = ArrayMetadata(
-            shape=(4, 4, 4), dtype=np.uint32, chunks=(4, 4, 4), attrs={},
-        )
+    def test_parent_funlib_pixelResolution(self):
+        data = _empty_meta()
+        parent_attrs = {
+            "pixelResolution": {"dimensions": [3, 2, 1], "unit": "nm"},
+        }
+        vs, _ = _read_voxel_size_offset(data, parent_attrs=parent_attrs)
+        # Reversed XYZ → ZYX
+        assert tuple(vs) == (1, 2, 3)
+
+    def test_no_parent_attrs_falls_back_to_unit(self):
+        data = _empty_meta()
         vs, off = _read_voxel_size_offset(data, parent_attrs=None)
         assert tuple(vs) == (1, 1, 1)
         assert tuple(off) == (0, 0, 0)
+
+    def test_non_integer_voxel_size_warns(self, caplog):
+        data = _empty_meta()
+        parent_attrs = {"multiscales": _multiscales_block([8.5, 8.5, 8.5], [0, 0, 0])}
+        with caplog.at_level(logging.WARNING, logger="mesh_n_bone.util.zarr_io"):
+            vs, _ = _read_voxel_size_offset(data, parent_attrs=parent_attrs)
+        assert tuple(vs) == (8, 8, 8)
+        assert any("non-integer voxel_size" in r.message for r in caplog.records)
+
+
+class TestPathMatching:
+    """``_extract_ome_scale_translation`` matches by dataset path (#1)."""
+
+    def test_matches_named_dataset(self):
+        ms = [{
+            "axes": [
+                {"name": "z", "type": "space"},
+                {"name": "y", "type": "space"},
+                {"name": "x", "type": "space"},
+            ],
+            "datasets": [
+                {
+                    "path": "s0",
+                    "coordinateTransformations": [
+                        {"type": "scale", "scale": [4, 4, 4]},
+                    ],
+                },
+                {
+                    "path": "s1",
+                    "coordinateTransformations": [
+                        {"type": "scale", "scale": [8, 8, 8]},
+                    ],
+                },
+            ],
+        }]
+        scale, _ = _extract_ome_scale_translation({"multiscales": ms}, dataset_name="s1")
+        assert scale == (8.0, 8.0, 8.0)
+
+    def test_falls_back_to_first_when_path_unknown(self):
+        ms = [{
+            "datasets": [
+                {
+                    "path": "s0",
+                    "coordinateTransformations": [{"type": "scale", "scale": [4, 4, 4]}],
+                },
+            ],
+        }]
+        scale, _ = _extract_ome_scale_translation({"multiscales": ms}, dataset_name="missing")
+        assert scale == (4.0, 4.0, 4.0)
+
+
+class TestTransformOrdering:
+    """``_read_transforms`` composes in document order regardless of layout (#2)."""
+
+    def test_scale_then_translation(self):
+        # physical = scale * voxel + translation  (the conventional order).
+        s, t = _read_transforms([
+            {"type": "scale", "scale": [2, 2, 2]},
+            {"type": "translation", "translation": [10, 10, 10]},
+        ])
+        assert s == [2.0, 2.0, 2.0]
+        assert t == [10.0, 10.0, 10.0]
+
+    def test_translation_then_scale(self):
+        # If translation is applied first, it lives in voxel space and
+        # must be scaled along with the rest:
+        # physical = scale * (translation + voxel) = scale * voxel + scale * translation.
+        s, t = _read_transforms([
+            {"type": "translation", "translation": [10, 10, 10]},
+            {"type": "scale", "scale": [2, 2, 2]},
+        ])
+        assert s == [2.0, 2.0, 2.0]
+        assert t == [20.0, 20.0, 20.0]
+
+    def test_identity_ignored(self):
+        s, t = _read_transforms([
+            {"type": "identity"},
+            {"type": "scale", "scale": [3, 3, 3]},
+        ])
+        assert s == [3.0, 3.0, 3.0]
+        assert t is None
+
+
+class TestAxesPermutation:
+    """OME-NGFF axes ordering and 5D filtering (#3)."""
+
+    def test_xyz_axes_reordered_to_zyx(self):
+        ms = [{
+            "axes": [
+                {"name": "x", "type": "space"},
+                {"name": "y", "type": "space"},
+                {"name": "z", "type": "space"},
+            ],
+            "datasets": [{
+                "path": "s0",
+                "coordinateTransformations": [
+                    {"type": "scale", "scale": [10, 20, 30]},  # x,y,z
+                    {"type": "translation", "translation": [1, 2, 3]},
+                ],
+            }],
+        }]
+        scale, trans = _extract_ome_scale_translation({"multiscales": ms})
+        # ZYX-ordered output
+        assert scale == (30.0, 20.0, 10.0)
+        assert trans == (3.0, 2.0, 1.0)
+
+    def test_5d_axes_filtered_to_spatial_zyx(self):
+        ms = [{
+            "axes": [
+                {"name": "t", "type": "time"},
+                {"name": "c", "type": "channel"},
+                {"name": "z", "type": "space"},
+                {"name": "y", "type": "space"},
+                {"name": "x", "type": "space"},
+            ],
+            "datasets": [{
+                "path": "s0",
+                "coordinateTransformations": [
+                    {"type": "scale", "scale": [1, 1, 4, 4, 4]},
+                ],
+            }],
+        }]
+        scale, _ = _extract_ome_scale_translation({"multiscales": ms})
+        assert scale == (4.0, 4.0, 4.0)
+
+    def test_no_axes_assumes_zyx(self):
+        ms = [{
+            "datasets": [{
+                "path": "s0",
+                "coordinateTransformations": [{"type": "scale", "scale": [1, 2, 3]}],
+            }],
+        }]
+        scale, _ = _extract_ome_scale_translation({"multiscales": ms})
+        assert scale == (1.0, 2.0, 3.0)
+
+
+class TestRootLevelComposition:
+    """Multiscales root-level coordinateTransformations compose with per-dataset (#4)."""
+
+    def test_root_scale_composes(self):
+        ms = [{
+            "axes": [
+                {"name": "z", "type": "space"},
+                {"name": "y", "type": "space"},
+                {"name": "x", "type": "space"},
+            ],
+            "datasets": [{
+                "path": "s0",
+                "coordinateTransformations": [{"type": "scale", "scale": [2, 2, 2]}],
+            }],
+            "coordinateTransformations": [
+                {"type": "scale", "scale": [4, 4, 4]},
+            ],
+        }]
+        scale, _ = _extract_ome_scale_translation({"multiscales": ms})
+        assert scale == (8.0, 8.0, 8.0)
+
+    def test_root_translation_after_dataset_scale(self):
+        # physical = root_translation + root_scale * dataset_translation
+        #            + (root_scale * dataset_scale) * voxel
+        ms = [{
+            "datasets": [{
+                "path": "s0",
+                "coordinateTransformations": [
+                    {"type": "scale", "scale": [2, 2, 2]},
+                    {"type": "translation", "translation": [5, 5, 5]},
+                ],
+            }],
+            "coordinateTransformations": [
+                {"type": "translation", "translation": [100, 100, 100]},
+            ],
+        }]
+        scale, trans = _extract_ome_scale_translation({"multiscales": ms})
+        assert scale == (2.0, 2.0, 2.0)
+        assert trans == (105.0, 105.0, 105.0)
+
+
+class TestForwardCompatWarning:
+    """Unrecognized ``ome`` block layout should warn (#6)."""
+
+    def test_warns_on_ome_without_multiscales(self, caplog):
+        attrs = {"ome": {"version": "0.6", "schema_url": "..."}}
+        with caplog.at_level(logging.WARNING, logger="mesh_n_bone.util.zarr_io"):
+            assert _get_multiscales(attrs) is None
+        assert any(
+            "ome" in r.message and "multiscales" in r.message for r in caplog.records
+        )
+
+
+class TestFunlibHelper:
+    def test_returns_none_when_empty(self):
+        assert _read_funlib_voxel_offset({}) == (None, None)
+        assert _read_funlib_voxel_offset(None) == (None, None)
+
+    def test_voxel_size_takes_precedence_over_pixelResolution(self):
+        attrs = {
+            "voxel_size": [4, 4, 4],
+            "pixelResolution": {"dimensions": [99, 99, 99]},
+        }
+        vs, _ = _read_funlib_voxel_offset(attrs)
+        assert vs == [4.0, 4.0, 4.0]

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -1,0 +1,185 @@
+"""Unit tests for OME-NGFF metadata helpers in mesh_n_bone.util.zarr_io."""
+
+import os
+
+import numpy as np
+import pytest
+import zarr
+
+from mesh_n_bone.util.zarr_io import (
+    _extract_ome_scale_translation,
+    _get_multiscales,
+    _read_voxel_size_offset,
+    open_dataset,
+    read_raw_voxel_size,
+)
+
+
+def _multiscales_block(scale, translation):
+    return [{
+        "axes": [
+            {"name": "z", "type": "space", "unit": "nanometer"},
+            {"name": "y", "type": "space", "unit": "nanometer"},
+            {"name": "x", "type": "space", "unit": "nanometer"},
+        ],
+        "datasets": [{
+            "coordinateTransformations": [
+                {"scale": list(scale), "type": "scale"},
+                {"translation": list(translation), "type": "translation"},
+            ],
+            "path": "s0",
+        }],
+        "version": "test",
+    }]
+
+
+class TestGetMultiscales:
+    """``_get_multiscales`` must accept v0.4 and v0.5 layouts."""
+
+    def test_v04_top_level(self):
+        attrs = {"multiscales": _multiscales_block([1, 2, 3], [0, 0, 0])}
+        assert _get_multiscales(attrs) is attrs["multiscales"]
+
+    def test_v05_ome_namespaced(self):
+        ms = _multiscales_block([1, 2, 3], [0, 0, 0])
+        attrs = {"ome": {"multiscales": ms, "version": "0.5"}}
+        assert _get_multiscales(attrs) is ms
+
+    def test_missing_returns_none(self):
+        assert _get_multiscales({}) is None
+        assert _get_multiscales({"ome": {}}) is None
+        assert _get_multiscales(None) is None
+
+    def test_v04_takes_precedence(self):
+        # If both layouts are present, top-level wins (it's the legacy path
+        # and matches existing cellmap datasets).
+        v04 = _multiscales_block([4, 4, 4], [0, 0, 0])
+        v05 = _multiscales_block([8, 8, 8], [0, 0, 0])
+        attrs = {"multiscales": v04, "ome": {"multiscales": v05}}
+        assert _get_multiscales(attrs) is v04
+
+
+class TestExtractOmeScaleTranslation:
+    """Reads scale and translation in either OME layout, preserving floats."""
+
+    def test_v04(self):
+        attrs = {"multiscales": _multiscales_block([8.0, 8.0, 8.0], [100, 100, 100])}
+        scale, trans = _extract_ome_scale_translation(attrs)
+        assert scale == (8.0, 8.0, 8.0)
+        assert trans == (100.0, 100.0, 100.0)
+
+    def test_v05(self):
+        ms = _multiscales_block([32.0, 32.0, 32.0], [12.0, 12.0, 12.0])
+        attrs = {"ome": {"multiscales": ms, "version": "0.5"}}
+        scale, trans = _extract_ome_scale_translation(attrs)
+        assert scale == (32.0, 32.0, 32.0)
+        assert trans == (12.0, 12.0, 12.0)
+
+    def test_non_integer_voxel_size_preserved(self):
+        # Sub-nanometer / non-integer scales must round-trip as floats so
+        # callers like read_raw_voxel_size don't lose precision.
+        attrs = {"multiscales": _multiscales_block([8.5, 8.5, 8.5], [0, 0, 0])}
+        scale, _ = _extract_ome_scale_translation(attrs)
+        assert scale == (8.5, 8.5, 8.5)
+
+    def test_missing_translation(self):
+        ms = [{
+            "axes": [],
+            "datasets": [{
+                "coordinateTransformations": [
+                    {"scale": [4, 4, 4], "type": "scale"},
+                ],
+                "path": "s0",
+            }],
+        }]
+        scale, trans = _extract_ome_scale_translation({"multiscales": ms})
+        assert scale == (4.0, 4.0, 4.0)
+        assert trans is None
+
+    def test_no_multiscales(self):
+        scale, trans = _extract_ome_scale_translation({})
+        assert scale is None
+        assert trans is None
+
+
+@pytest.fixture
+def _ome_zarr_factory(tmp_output_dir):
+    """Build a tiny zarr v3 group with multiscales metadata in either layout."""
+
+    def _make(ome_version, scale=(8, 16, 32), translation=(10, 20, 30)):
+        zarr_path = os.path.join(tmp_output_dir, f"ome_{ome_version}.zarr")
+        root = zarr.open_group(zarr_path, mode="w")
+        root.create_array(
+            "seg/s0",
+            data=np.zeros((4, 4, 4), dtype=np.uint32),
+            chunks=(4, 4, 4),
+        )
+        ms = _multiscales_block(scale, translation)
+        if ome_version == "0.5":
+            root["seg"].attrs["ome"] = {"multiscales": ms, "version": "0.5"}
+        else:
+            root["seg"].attrs["multiscales"] = ms
+        return f"{zarr_path}/seg/s0"
+
+    return _make
+
+
+class TestOpenDatasetOmeFallback:
+    """``open_dataset`` must pick up voxel_size/offset from either layout."""
+
+    @pytest.mark.parametrize("ome_version", ["0.4", "0.5"])
+    def test_open_dataset_picks_up_ome(self, _ome_zarr_factory, ome_version):
+        path = _ome_zarr_factory(ome_version)
+        ds = open_dataset(*os.path.split(path))
+        assert tuple(ds.voxel_size) == (8, 16, 32)
+        # offset propagates into the ROI begin in physical units.
+        assert tuple(ds.roi.begin) == (10, 20, 30)
+
+    @pytest.mark.parametrize("ome_version", ["0.4", "0.5"])
+    def test_read_raw_voxel_size_picks_up_ome(self, _ome_zarr_factory, ome_version):
+        # Floats must survive the parent-traversal path used by read_raw_voxel_size.
+        path = _ome_zarr_factory(ome_version)
+        ds = open_dataset(*os.path.split(path))
+        raw = read_raw_voxel_size(ds)
+        assert raw == (8.0, 16.0, 32.0)
+
+
+class TestReadVoxelSizeOffsetParentFallback:
+    """The ``parent_attrs`` parameter feeds the OME multiscales fallback."""
+
+    def test_array_attrs_take_precedence_over_parent(self):
+        # If the array carries explicit voxel_size, the OME parent fallback
+        # must not override it.
+        from mesh_n_bone.util.zarr_io import ArrayMetadata
+
+        data = ArrayMetadata(
+            shape=(4, 4, 4),
+            dtype=np.uint32,
+            chunks=(4, 4, 4),
+            attrs={"voxel_size": [2, 2, 2], "offset": [1, 1, 1]},
+        )
+        parent_attrs = {"multiscales": _multiscales_block([8, 8, 8], [9, 9, 9])}
+        vs, off = _read_voxel_size_offset(data, parent_attrs=parent_attrs)
+        assert tuple(vs) == (2, 2, 2)
+        assert tuple(off) == (1, 1, 1)
+
+    def test_parent_fallback_when_array_empty(self):
+        from mesh_n_bone.util.zarr_io import ArrayMetadata
+
+        data = ArrayMetadata(
+            shape=(4, 4, 4), dtype=np.uint32, chunks=(4, 4, 4), attrs={},
+        )
+        parent_attrs = {"ome": {"multiscales": _multiscales_block([8, 8, 8], [9, 9, 9])}}
+        vs, off = _read_voxel_size_offset(data, parent_attrs=parent_attrs)
+        assert tuple(vs) == (8, 8, 8)
+        assert tuple(off) == (9, 9, 9)
+
+    def test_no_parent_attrs_falls_back_to_unit(self):
+        from mesh_n_bone.util.zarr_io import ArrayMetadata
+
+        data = ArrayMetadata(
+            shape=(4, 4, 4), dtype=np.uint32, chunks=(4, 4, 4), attrs={},
+        )
+        vs, off = _read_voxel_size_offset(data, parent_attrs=None)
+        assert tuple(vs) == (1, 1, 1)
+        assert tuple(off) == (0, 0, 0)


### PR DESCRIPTION
## Summary

- Read voxel size and offset correctly from **OME-Zarr v0.5** (`attrs.ome.multiscales`) parent groups in addition to v0.4. Without this, paintera-exported v0.5 datasets silently fell back to `voxel_size=(1,1,1)` and produced meshes 32× too small (or whatever the true scale was).
- Harden the OME multiscales reader against several spec corners that previously silently produced wrong values: non-first dataset paths (e.g. opening `s2`), non-ZYX axes (`[x,y,z]` or 4D/5D axes lists with non-spatial dims), root-level `coordinateTransformations` composed on top of per-dataset transforms, and `[translation, scale]` declaration order.
- Add a parent-group fallback for funlib/N5 metadata (`resolution`, `voxel_size`, `pixelResolution`, `offset`) so N5 multiscales setups that put resolution on the group level work too.
- Promote the hardcoded `25_000`-faces-per-fragment heuristic in the multires LOD-0 box-sizing logic to a configurable `target_faces_per_lod0_chunk`, plumbed through `Meshify`, the multires pipeline's `run-config`, and `generate_(all_)neuroglancer_multires_mesh(es)`. Default behaviour is unchanged.
- Surface a clear warning when an `ome:` block is present but doesn't carry `multiscales` (forward-compat for future spec layouts), and a warning when non-integer voxel sizes are silently rounded by the `Coordinate` path (pointing callers at `read_raw_voxel_size`).

## Test plan

- [x] New `tests/test_zarr_io.py` (32 unit tests) covering both v0.4 / v0.5 layouts, layout precedence, missing translation, non-integer voxel sizes, parent-attrs precedence over array attrs, `_read_transforms` order awareness, axes permutation (XYZ → ZYX, 5D → ZYX), root-level transform composition, and forward-compat warning.
- [x] New v0.5 fixture `zarr_cube_ome_ngff_v05` in `conftest.py` and integration test `TestOmeNgffCoordinates::test_ome_ngff_v05_cube_bounds` mirroring the existing v0.4 case.
- [x] New `TestTargetFacesPerLod0Chunk` integration test verifying that lowering the threshold produces more LODs than the default on a small mesh.
- [x] Full suite: `pixi run -e test python -m pytest tests/` → **226 passed, 3 skipped**.
- [x] End-to-end: ran `mesh-n-bone meshify` on a paintera v0.5 dataset (`jrc_mosquito-stylet-6` cells + nuclei) on the cluster with no array-level voxel-size workaround — meshes register correctly against the EM image in neuroglancer.