### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -6073,7 +6073,7 @@ packages:
   requires_python: '>=3.9'
 - pypi: .
   name: mesh-n-bone
-  version: 0.1.2
+  version: 0.1.3
   sha256: 02191c7e57f0bf5682d688ef2ecf71288e5fe18534a47e9575f58b9fe42bed9f
   requires_dist:
   - numpy

--- a/pixi.lock
+++ b/pixi.lock
@@ -6074,7 +6074,7 @@ packages:
 - pypi: .
   name: mesh-n-bone
   version: 0.1.3
-  sha256: 02191c7e57f0bf5682d688ef2ecf71288e5fe18534a47e9575f58b9fe42bed9f
+  sha256: c7978f776457471f5ee966ba45b2b10ccbd3093148c1b335d296d59a11de4cf4
   requires_dist:
   - numpy
   - trimesh>=4.6.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mesh-n-bone"
-version = "0.1.2"
+version = "0.1.3"
 description = "Unified tool for mesh generation, multiresolution mesh creation, skeletonization, and analysis."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Includes the OME-Zarr v0.5 fix and configurable LOD-0 chunk-face threshold landed in #17.