### PR TITLE
Bug fixes (nested zarr path + multires LOD cap) + bump to 0.1.4

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -6073,8 +6073,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: .
   name: mesh-n-bone
-  version: 0.1.3
-  sha256: c7978f776457471f5ee966ba45b2b10ccbd3093148c1b335d296d59a11de4cf4
+  version: 0.1.4
+  sha256: 75e34d92fa84b0f1065cf2ba7f6c84a50742f48df339ff77367553fb0de98ad8
   requires_dist:
   - numpy
   - trimesh>=4.6.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mesh-n-bone"
-version = "0.1.3"
+version = "0.1.4"
 description = "Unified tool for mesh generation, multiresolution mesh creation, skeletonization, and analysis."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mesh_n_bone/multires/multires.py
+++ b/src/mesh_n_bone/multires/multires.py
@@ -121,12 +121,18 @@ def generate_neuroglancer_multires_mesh(
             np.ceil(mesh_extent / lod_0_box_size).astype(int), 1
         )
 
-        # For meshes that fit in a single chunk, drop to 1 LOD.
-        # With 1 LOD the octree is just 1 cell, so grid_origin
-        # centers the mesh exactly and there are no internal chunk
-        # boundaries that would create LOD-transition seam artifacts.
-        if np.all(num_chunks_per_axis == 1) and len(lods) > 1:
-            lods = lods[:1]
+        # Cap len(lods) at the smallest count whose top-LOD chunk
+        # already covers the mesh. The octree top must satisfy
+        # ``2^(len(lods)-1) >= max(num_chunks_per_axis)``; going beyond
+        # that just doubles ``total_chunks_per_axis`` per extra LOD,
+        # which inflates the listed-fragment grid (every top-LOD parent
+        # demands all its LOD-0 children, even empty ones) and pushes
+        # NG's segment bounding box — and the camera fly-to that uses
+        # it — far away from the actual mesh.
+        max_chunks = int(num_chunks_per_axis.max())
+        max_useful_lods = int(np.ceil(np.log2(max_chunks))) + 1 if max_chunks > 1 else 1
+        if len(lods) > max_useful_lods:
+            lods = lods[:max_useful_lods]
 
         # Center the mesh within the full octree grid so that
         # Neuroglancer's bounding-box center matches the actual mesh

--- a/src/mesh_n_bone/util/zarr_io.py
+++ b/src/mesh_n_bone/util/zarr_io.py
@@ -93,7 +93,9 @@ def split_dataset_path(dataset_path):
     splitter = (
         ".zarr" if dataset_path.rfind(".zarr") > dataset_path.rfind(".n5") else ".n5"
     )
-    parts = dataset_path.split(splitter)
+    # Split on the LAST occurrence so nested containers like
+    # ``outer.zarr/inner.zarr/s0`` resolve to ``inner.zarr`` + ``s0``.
+    parts = dataset_path.rsplit(splitter, 1)
     container = parts[0] + splitter
     dataset_name = parts[1].lstrip("/") if len(parts) > 1 else ""
     return container, dataset_name

--- a/tests/test_integration_multires.py
+++ b/tests/test_integration_multires.py
@@ -405,6 +405,62 @@ class TestLodTruncation:
         # LOD 1 has same face count as LOD 0, so it should be truncated
         assert num_lods == 1
 
+    def test_lods_capped_to_octree_unit_covering_mesh(self, multires_mesh_dir):
+        """Excess LODs are dropped when ``octree_unit`` already covers the mesh.
+
+        With ``num_chunks_per_axis=[2,2,2]`` and the user requesting 4 LODs,
+        ``octree_unit`` would be 8 — listing 8x8x8=512 fragments at LOD 0
+        for a mesh that only occupies a 2x2x2 cube. NG's segment bounding
+        box would then span the full grid, so camera fly-to lands far
+        from the mesh. Cap LODs at the smallest count whose top-LOD
+        chunk already covers the mesh.
+        """
+        output_path = multires_mesh_dir
+
+        # Force num_chunks_per_axis = [2,2,2] via small box_size
+        # (mesh extent ~2.0 in each axis, box_size 1.0 → 2 chunks/axis).
+        # Request 4 LODs; expect cap at 2 (since log2(2) + 1 = 2).
+        generate_neuroglancer_multires_mesh(
+            id=1,
+            num_subtask_workers=1,
+            output_path=output_path,
+            lods=[0, 1, 2, 3],
+            original_ext=".ply",
+            lod_0_box_size=np.array([1.0, 1.0, 1.0]),
+        )
+
+        index_file = os.path.join(output_path, "multires", "1.index")
+        with open(index_file, "rb") as f:
+            data = f.read()
+        chunk_shape = np.frombuffer(data, "<f", 3, 0).copy()
+        grid_origin = np.frombuffer(data, "<f", 3, 12).copy()
+        num_lods = struct.unpack("<I", data[24:28])[0]
+
+        # Expect the cap: max(num_chunks)=2 → log2(2)+1 = 2 LODs.
+        assert num_lods == 2, (
+            f"Expected 2 LODs after cap, got {num_lods}. "
+            "Excess LODs should be dropped to avoid bloated empty grids."
+        )
+
+        # And the LOD-0 listed-fragment grid should be tight around the mesh.
+        off = 28 + 4 * num_lods + 12 * num_lods
+        num_frags_per_lod = np.frombuffer(data, "<I", num_lods, off).copy()
+        off += 4 * num_lods
+        nf = num_frags_per_lod[0]
+        positions = np.frombuffer(data, "<I", nf * 3, off).reshape(3, nf).T.copy()
+        listed_extent = (positions.max(axis=0) + 1 - positions.min(axis=0)) * chunk_shape
+
+        from mesh_n_bone.util.mesh_io import mesh_loader
+        verts, _ = mesh_loader(os.path.join(output_path, "mesh_lods", "s0", "1.ply"))
+        mesh_extent = verts.max(axis=0) - verts.min(axis=0)
+
+        # Listed grid should be within 2x mesh extent (allows octree-unit
+        # rounding, but rejects the 8x bloat from the un-capped case).
+        assert np.all(listed_extent <= 2.0 * mesh_extent + chunk_shape), (
+            f"Listed-fragment extent {listed_extent} too large for mesh "
+            f"extent {mesh_extent} (chunk_shape {chunk_shape})."
+        )
+
     def test_three_lods_all_valid(self, tmp_output_dir):
         """Three LODs with progressively fewer faces should all be included."""
         output_path = os.path.join(tmp_output_dir, "three_lods")


### PR DESCRIPTION
## Summary

Two bug fixes shipping in 0.1.4:

### 1. Nested zarr path resolution
`split_dataset_path` used `str.split(".zarr")` and only kept `parts[1]`, so a nested-container path like `outer.zarr/inner.zarr/multiscale/s0` produced container `outer.zarr` and dataset `inner` — silently dropping `multiscale/s0`. Switched to `rsplit(splitter, 1)` so the rightmost `.zarr`/`.n5` marks the container boundary.

### 2. Multires LOD count cap
Requesting more LODs than the mesh extent justifies produced an octree grid much larger than the mesh (e.g. 4 LODs for a 2×2×2-chunk mesh inflates to 8×8×8 = 512 LOD-0 cells, where only ~5 hold geometry). The 500+ empty placeholders are required by spec, so NG's segment-bounding-box computation includes them — camera fly-to lands at the centre of the bloated grid, far from the actual mesh.

Cap `len(lods)` at the smallest count whose top-LOD chunk already covers the mesh: `ceil(log2(max(num_chunks_per_axis))) + 1`. Subsumes the prior single-chunk truncation.

### Version
Bumps to 0.1.4 (with regenerated `pixi.lock` sha256) so the fixes ship to PyPI on tag.