### PR TITLE
Multires writer fixes + zarr nested-container fix + 0.1.4

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -6073,8 +6073,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: .
   name: mesh-n-bone
-  version: 0.1.3
-  sha256: c7978f776457471f5ee966ba45b2b10ccbd3093148c1b335d296d59a11de4cf4
+  version: 0.1.4
+  sha256: 75e34d92fa84b0f1065cf2ba7f6c84a50742f48df339ff77367553fb0de98ad8
   requires_dist:
   - numpy
   - trimesh>=4.6.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mesh-n-bone"
-version = "0.1.3"
+version = "0.1.4"
 description = "Unified tool for mesh generation, multiresolution mesh creation, skeletonization, and analysis."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mesh_n_bone/multires/decomposition.py
+++ b/src/mesh_n_bone/multires/decomposition.py
@@ -211,6 +211,24 @@ def generate_mesh_decomposition(
                 local_vertices = fragment.vertices.astype(np.float64) - quantization_origin
                 local_vertices = np.clip(local_vertices, 0.0, current_box_size)
 
+                # Snap vertices that fall within half a quantization
+                # step of a chunk boundary to the boundary itself. The
+                # slicer may emit boundary vertices a hair off the
+                # plane in float64; without this snap the same
+                # conceptual vertex in two adjacent chunks can round
+                # to two different lattice positions, decoding to two
+                # slightly-different world coords and creating a
+                # visible sub-pixel seam at every chunk boundary.
+                half_step = current_box_size / max_q / 2.0
+                local_vertices = np.where(
+                    local_vertices < half_step, 0.0, local_vertices,
+                )
+                local_vertices = np.where(
+                    local_vertices > current_box_size - half_step,
+                    current_box_size,
+                    local_vertices,
+                )
+
                 # Compute integer quantized positions per axis
                 int_positions = np.round(
                     local_vertices * (max_q / current_box_size)

--- a/src/mesh_n_bone/multires/multires.py
+++ b/src/mesh_n_bone/multires/multires.py
@@ -68,6 +68,15 @@ def generate_neuroglancer_multires_mesh(
 
         vertex_min = None
         vertex_max = None
+        # Union of vertex bboxes across ALL valid LODs. The grid below
+        # is sized from LOD 0's bbox (the canonical extent), but
+        # decimated LODs can drift slightly outside it; the empty-
+        # placeholder logic needs to cover the full union so NG always
+        # has a finer-LOD fragment under any region a coarser LOD has
+        # geometry in (otherwise zoom-in transitions show two scales
+        # at once on the regions LOD 0 doesn't cover but LOD 1+ does).
+        union_vertex_min = None
+        union_vertex_max = None
         previous_num_faces = np.inf
         for idx, current_lod in enumerate(lods):
             if current_lod == 0:
@@ -82,31 +91,43 @@ def generate_neuroglancer_multires_mesh(
             num_faces = len(faces)
             if num_faces >= previous_num_faces:
                 break
-            # Use s0 bounds only for grid computation — decimated LODs
-            # can expand beyond s0 due to pyfqmr vertex movement.
+            # LOD-0 bounds drive the chunk grid; union bounds drive
+            # the empty-placeholder envelope (which must cover every
+            # LOD's actual face footprint, not just LOD 0's).
             if current_lod == 0 and vertices is not None:
                 vertex_min = vertices.min(axis=0)
                 vertex_max = vertices.max(axis=0)
+            if vertices is not None and len(vertices) > 0:
+                lod_vmin = vertices.min(axis=0)
+                lod_vmax = vertices.max(axis=0)
+                if union_vertex_min is None:
+                    union_vertex_min = lod_vmin.copy()
+                    union_vertex_max = lod_vmax.copy()
+                else:
+                    union_vertex_min = np.minimum(union_vertex_min, lod_vmin)
+                    union_vertex_max = np.maximum(union_vertex_max, lod_vmax)
 
             if lod_0_box_size is None and current_lod == 0:
                 distances_per_axis = np.ceil(
                     vertices.max(axis=0) - vertices.min(axis=0)
                 )
-                # Target ``target_faces_per_lod0_chunk`` faces per LOD-0
-                # fragment (default 25k ≈ 30 KB Draco-compressed at
-                # 10-bit quantization).  This balances spatial
-                # selectivity against HTTP per-request overhead.
+                # Surface-area scaling: triangles distribute across the
+                # mesh's 2-D surface, so total chunks ∝ N²-on-axis. Use
+                # sqrt for the per-axis count.
                 heuristic_num_chunks = np.ceil(num_faces / target_faces_per_lod0_chunk)
-                if heuristic_num_chunks == 1:
-                    lod_0_box_size = distances_per_axis + 1
-                else:
-                    lod_0_box_size = (
-                        np.ceil(
-                            distances_per_axis
-                            / np.ceil(heuristic_num_chunks ** (1 / 2))
-                        )
-                        + 1
-                    )
+                num_chunks_per_axis = max(
+                    1, int(np.ceil(np.sqrt(heuristic_num_chunks)))
+                )
+                # Cap so each top-LOD chunk fits within the mesh extent
+                # along every axis. Otherwise NG's per-chunk LOD-select
+                # gate doesn't fire for the oversized root chunk and
+                # the coarsest LOD stays painted persistently. The
+                # constraint is num_chunks_per_axis >= octree_unit.
+                octree_unit = 2 ** (len(lods) - 1)
+                num_chunks_per_axis = max(num_chunks_per_axis, octree_unit)
+                lod_0_box_size = (
+                    np.ceil(distances_per_axis / num_chunks_per_axis) + 1
+                )
 
             previous_num_faces = num_faces
         else:
@@ -121,12 +142,11 @@ def generate_neuroglancer_multires_mesh(
             np.ceil(mesh_extent / lod_0_box_size).astype(int), 1
         )
 
-        # For meshes that fit in a single chunk, drop to 1 LOD.
-        # With 1 LOD the octree is just 1 cell, so grid_origin
-        # centers the mesh exactly and there are no internal chunk
-        # boundaries that would create LOD-transition seam artifacts.
-        if np.all(num_chunks_per_axis == 1) and len(lods) > 1:
-            lods = lods[:1]
+        # No LOD-count truncation here. The union-bbox empty-placeholder
+        # logic in ``rewrite_index_with_empty_fragments`` keeps the
+        # listed-fragment grid tight regardless of LOD count, and a
+        # single-LOD-0-chunk mesh still benefits from extra decimation
+        # passes when the user is zoomed far out.
 
         # Center the mesh within the full octree grid so that
         # Neuroglancer's bounding-box center matches the actual mesh
@@ -143,6 +163,20 @@ def generate_neuroglancer_multires_mesh(
             grid_origin,
             np.ceil(vertex_max - full_grid_extent),
             np.floor(vertex_min),
+        )
+
+        # Convert union-of-LOD-vertex bbox to LOD-0 chunk units. This is
+        # the face-correct footprint we list at every LOD: a chunk with
+        # any face in any LOD must have a fragment (possibly empty) at
+        # every other LOD whose chunk contains it, so cross-LOD zoom
+        # transitions don't show two scales side by side.
+        union_lod0_min = np.maximum(
+            np.floor((union_vertex_min - grid_origin) / lod_0_box_size).astype(int),
+            0,
+        )
+        union_lod0_max = np.maximum(
+            np.ceil((union_vertex_max - grid_origin) / lod_0_box_size).astype(int),
+            union_lod0_min + 1,
         )
 
         results = []
@@ -240,6 +274,8 @@ def generate_neuroglancer_multires_mesh(
                     current_lod,
                     lods[: idx + 1],
                     np.asarray(lod_0_box_size, dtype=float),
+                    union_lod0_min=union_lod0_min,
+                    union_lod0_max=union_lod0_max,
                 )
 
                 del fragments

--- a/src/mesh_n_bone/multires/multires.py
+++ b/src/mesh_n_bone/multires/multires.py
@@ -107,26 +107,14 @@ def generate_neuroglancer_multires_mesh(
                     union_vertex_min = np.minimum(union_vertex_min, lod_vmin)
                     union_vertex_max = np.maximum(union_vertex_max, lod_vmax)
 
-            if lod_0_box_size is None and current_lod == 0:
-                distances_per_axis = np.ceil(
+            # Capture LOD-0 face count for the chunk-shape heuristic
+            # below. We compute lod_0_box_size AFTER the loop so the
+            # octree_unit cap uses the effective num_lods (after any
+            # face-count truncation), not the requested num_lods.
+            if current_lod == 0:
+                lod0_num_faces = num_faces
+                lod0_distances_per_axis = np.ceil(
                     vertices.max(axis=0) - vertices.min(axis=0)
-                )
-                # Surface-area scaling: triangles distribute across the
-                # mesh's 2-D surface, so total chunks ∝ N²-on-axis. Use
-                # sqrt for the per-axis count.
-                heuristic_num_chunks = np.ceil(num_faces / target_faces_per_lod0_chunk)
-                num_chunks_per_axis = max(
-                    1, int(np.ceil(np.sqrt(heuristic_num_chunks)))
-                )
-                # Cap so each top-LOD chunk fits within the mesh extent
-                # along every axis. Otherwise NG's per-chunk LOD-select
-                # gate doesn't fire for the oversized root chunk and
-                # the coarsest LOD stays painted persistently. The
-                # constraint is num_chunks_per_axis >= octree_unit.
-                octree_unit = 2 ** (len(lods) - 1)
-                num_chunks_per_axis = max(num_chunks_per_axis, octree_unit)
-                lod_0_box_size = (
-                    np.ceil(distances_per_axis / num_chunks_per_axis) + 1
                 )
 
             previous_num_faces = num_faces
@@ -135,6 +123,30 @@ def generate_neuroglancer_multires_mesh(
             idx += 1
 
         lods = lods[:idx]
+
+        if lod_0_box_size is None:
+            # Surface-area scaling: triangles distribute across the
+            # mesh's 2-D surface, so total chunks ∝ N²-on-axis. Use
+            # sqrt for the per-axis count.
+            heuristic_num_chunks = np.ceil(
+                lod0_num_faces / target_faces_per_lod0_chunk
+            )
+            num_chunks_per_axis = max(
+                1, int(np.ceil(np.sqrt(heuristic_num_chunks)))
+            )
+            # Cap so each top-LOD chunk fits within the mesh extent
+            # along every axis. Otherwise NG's per-chunk LOD-select
+            # gate doesn't fire for the oversized root chunk and the
+            # coarsest LOD stays painted persistently. The constraint
+            # is num_chunks_per_axis >= octree_unit, using the
+            # effective num_lods after truncation (uses requested
+            # num_lods would inflate chunk count for meshes whose
+            # face-count monotonicity check truncates LODs).
+            octree_unit = 2 ** (len(lods) - 1)
+            num_chunks_per_axis = max(num_chunks_per_axis, octree_unit)
+            lod_0_box_size = (
+                np.ceil(lod0_distances_per_axis / num_chunks_per_axis) + 1
+            )
 
         # Compute the LOD 0 chunk grid from the s0 mesh extent.
         mesh_extent = vertex_max - vertex_min

--- a/src/mesh_n_bone/util/mesh_io.py
+++ b/src/mesh_n_bone/util/mesh_io.py
@@ -167,22 +167,34 @@ def zorder_fragments(fragments):
     return list(fragments)
 
 
-def rewrite_index_with_empty_fragments(path, current_lod_fragments):
-    """Rewrite an existing index file, inserting empty fragments for completeness.
+def rewrite_index_with_empty_fragments(
+    path, current_lod_fragments,
+    union_lod0_min=None, union_lod0_max=None,
+):
+    """Append a new LOD's fragments to an existing index file.
 
-    Neuroglancer requires that every parent fragment at a coarser LOD has all
-    of its child fragments present (even if empty) so that LOD transitions
-    work correctly. This function reads the current ``.index`` file, computes
-    which child fragments are missing, inserts zero-length placeholders, and
-    writes the updated index back.
+    For every LOD this writes the existing non-empty fragments plus
+    empty (offset=0) placeholders covering the *union* of every LOD's
+    vertex bbox in LOD-0 chunk units. Empty placeholders signal to
+    NG's per-chunk LOD selector that the corresponding sub-chunk is
+    genuinely empty (not just unloaded), so NG can replace the parent
+    LOD with finer LODs over those regions cleanly.
+
+    Vertex AABB == triangle AABB for triangular faces, so unioning
+    vertex bboxes is face-correct: a triangle that spans multiple
+    chunks is still bounded by its three vertices' AABB.
 
     Parameters
     ----------
     path : str
-        Base path for the mesh (without ``.index`` suffix). The index file is
-        expected at ``path + ".index"``.
+        Base path for the mesh (without ``.index`` suffix). The index
+        file is expected at ``path + ".index"``.
     current_lod_fragments : list[CompressedFragment]
         Newly created fragments for the next LOD level to be appended.
+    union_lod0_min, union_lod0_max : numpy.ndarray, optional
+        Inclusive-min / exclusive-max LOD-0 chunk indices defining the
+        envelope of chunks to enumerate empty placeholders for. When
+        omitted, falls back to the LOD-0 fragment positions only.
     """
 
     with open(f"{path}.index", mode="rb") as file:
@@ -223,37 +235,33 @@ def rewrite_index_with_empty_fragments(path, current_lod_fragments):
         [fragment.offset for fragment in current_lod_fragments]
     )
 
+    # Use caller-provided union bbox if given, else fall back to the
+    # LOD-0 fragment positions only.
+    if union_lod0_min is None or union_lod0_max is None:
+        lod0_positions = np.asarray(all_current_fragment_positions[0]).reshape(-1, 3)
+        if lod0_positions.size > 0:
+            union_lod0_min = lod0_positions.min(axis=0).astype(int)
+            union_lod0_max = (lod0_positions.max(axis=0) + 1).astype(int)
+    else:
+        union_lod0_min = np.asarray(union_lod0_min, dtype=int)
+        union_lod0_max = np.asarray(union_lod0_max, dtype=int)
+
     all_missing_fragment_positions = []
     for lod in range(num_lods):
-        all_required_fragment_positions = set()
-
-        if lod == current_lod:
-            for lower_lod in range(lod):
-                all_required_fragment_positions_np = np.unique(
-                    all_current_fragment_positions[lower_lod] // 2 ** (lod - lower_lod),
-                    axis=0,
-                ).astype(int)
-                all_required_fragment_positions.update(
-                    set(map(tuple, all_required_fragment_positions_np))
-                )
+        scale = 2 ** lod
+        if union_lod0_min is None:
+            required = set()
         else:
-            # For each new LOD fragment at position p, ALL children at
-            # LOD `lod` must exist (even if empty) so neuroglancer can
-            # properly replace the parent with its children.  Enumerate
-            # every child position from p*scale to (p+1)*scale - 1.
-            for fragment in current_lod_fragments:
-                scale = 2 ** (current_lod - lod)
-                base = (np.asarray(fragment.position) * scale).astype(int)
-                for dx in range(scale):
-                    for dy in range(scale):
-                        for dz in range(scale):
-                            all_required_fragment_positions.add(
-                                (base[0] + dx, base[1] + dy, base[2] + dz)
-                            )
-        current_missing_fragment_positions = all_required_fragment_positions - set(
-            map(tuple, all_current_fragment_positions[lod])
-        )
-        all_missing_fragment_positions.append(current_missing_fragment_positions)
+            lo = (union_lod0_min // scale).astype(int)
+            hi = ((union_lod0_max + scale - 1) // scale).astype(int)
+            required = {
+                (x, y, z)
+                for x in range(lo[0], hi[0])
+                for y in range(lo[1], hi[1])
+                for z in range(lo[2], hi[2])
+            }
+        existing = set(map(tuple, all_current_fragment_positions[lod]))
+        all_missing_fragment_positions.append(required - existing)
 
     num_fragments_per_lod = []
     all_fragment_positions = []
@@ -304,7 +312,10 @@ def rewrite_index_with_empty_fragments(path, current_lod_fragments):
     os.system(f"mv {path}.index_with_empty_fragments {path}.index")
 
 
-def write_index_file(path, grid_origin, fragments, current_lod, lods, chunk_shape):
+def write_index_file(
+    path, grid_origin, fragments, current_lod, lods, chunk_shape,
+    union_lod0_min=None, union_lod0_max=None,
+):
     """Write or update the ``.index`` file for a multi-LOD Draco mesh.
 
     If this is the first LOD or no index file exists yet, a new file is
@@ -325,6 +336,8 @@ def write_index_file(path, grid_origin, fragments, current_lod, lods, chunk_shap
         All LOD levels that have been (or will be) generated.
     chunk_shape : numpy.ndarray
         Size of a single LOD 0 chunk in model coordinates, shape ``(3,)``.
+    union_lod0_min, union_lod0_max : numpy.ndarray, optional
+        Forwarded to ``rewrite_index_with_empty_fragments`` (see there).
     """
     lods = [lod for lod in lods if lod <= current_lod]
 
@@ -351,7 +364,10 @@ def write_index_file(path, grid_origin, fragments, current_lod, lods, chunk_shap
                 .tobytes(order="C")
             )
     else:
-        rewrite_index_with_empty_fragments(path, fragments)
+        rewrite_index_with_empty_fragments(
+            path, fragments,
+            union_lod0_min=union_lod0_min, union_lod0_max=union_lod0_max,
+        )
 
 
 def write_mesh_file(path, fragments):
@@ -382,7 +398,8 @@ def write_mesh_file(path, fragments):
 
 
 def write_mesh_files(
-    mesh_directory, object_id, grid_origin, fragments, current_lod, lods, chunk_shape
+    mesh_directory, object_id, grid_origin, fragments, current_lod, lods, chunk_shape,
+    union_lod0_min=None, union_lod0_max=None,
 ):
     """Write the mesh data and index files for a single segment.
 
@@ -405,9 +422,18 @@ def write_mesh_files(
         All LOD levels that have been (or will be) generated.
     chunk_shape : numpy.ndarray
         Size of a single LOD 0 chunk in model coordinates, shape ``(3,)``.
+    union_lod0_min, union_lod0_max : numpy.ndarray, optional
+        Inclusive-min / exclusive-max bounds (in LOD-0 chunk index units)
+        of the union of every LOD's vertex bbox. Used by
+        ``rewrite_index_with_empty_fragments`` to enumerate empty
+        placeholders covering the actual face footprint of every LOD.
+        If omitted, falls back to the LOD-0 fragment positions only.
     """
     path = mesh_directory + "/" + object_id
     if len(fragments) > 0:
         fragments = zorder_fragments(fragments)
         fragments = write_mesh_file(path, fragments)
-        write_index_file(path, grid_origin, fragments, current_lod, lods, chunk_shape)
+        write_index_file(
+            path, grid_origin, fragments, current_lod, lods, chunk_shape,
+            union_lod0_min=union_lod0_min, union_lod0_max=union_lod0_max,
+        )

--- a/src/mesh_n_bone/util/zarr_io.py
+++ b/src/mesh_n_bone/util/zarr_io.py
@@ -93,7 +93,9 @@ def split_dataset_path(dataset_path):
     splitter = (
         ".zarr" if dataset_path.rfind(".zarr") > dataset_path.rfind(".n5") else ".n5"
     )
-    parts = dataset_path.split(splitter)
+    # Split on the LAST occurrence so nested containers like
+    # ``outer.zarr/inner.zarr/s0`` resolve to ``inner.zarr`` + ``s0``.
+    parts = dataset_path.rsplit(splitter, 1)
     container = parts[0] + splitter
     dataset_name = parts[1].lstrip("/") if len(parts) > 1 else ""
     return container, dataset_name

--- a/tests/test_integration_multires.py
+++ b/tests/test_integration_multires.py
@@ -405,6 +405,81 @@ class TestLodTruncation:
         # LOD 1 has same face count as LOD 0, so it should be truncated
         assert num_lods == 1
 
+    def test_listed_grid_stays_tight_with_many_lods(self, tmp_output_dir):
+        """Listed-fragment grid tracks union mesh extent, not ``octree_unit``.
+
+        Regression for the empty-placeholder bloat: requesting more LODs
+        than the mesh strictly needs used to inflate
+        ``total_chunks_per_axis`` to ``2^(num_lods-1)``, listing
+        ``octree_unit^3`` LOD-0 placeholders per top-LOD parent (e.g. 512
+        for 4 LODs over a 2x2x2-chunk mesh). NG read those positions for
+        its segment bounding box, so camera fly-to landed far outside
+        the mesh. The fix lists only chunks that intersect the union of
+        per-LOD mesh footprints, so the listed grid stays close to the
+        mesh AABB regardless of LOD count.
+        """
+        import pyfqmr
+
+        output_path = os.path.join(tmp_output_dir, "many_lods_tight")
+        mesh_lods = os.path.join(output_path, "mesh_lods")
+        mesh = trimesh.creation.icosphere(subdivisions=4, radius=50.0)
+        mesh.vertices += 100  # offset to positive coords
+
+        for lod in range(4):
+            lod_dir = os.path.join(mesh_lods, f"s{lod}")
+            os.makedirs(lod_dir)
+            if lod == 0:
+                mesh.export(os.path.join(lod_dir, "1.ply"))
+            else:
+                simp = pyfqmr.Simplify()
+                simp.setMesh(mesh.vertices, mesh.faces)
+                target = max(len(mesh.faces) // (4 ** lod), 4)
+                simp.simplify_mesh(
+                    target_count=target, aggressiveness=7,
+                    preserve_border=False, verbose=False,
+                )
+                v, f, _ = simp.getMesh()
+                trimesh.Trimesh(v, f).export(os.path.join(lod_dir, "1.ply"))
+
+        # box_size of 50 → mesh extent (100) gives 2 LOD-0 chunks per axis.
+        # Request 4 LODs; with the old code this produced an 8x8x8 listed
+        # grid. Expect the listed grid to stay within ~2x mesh extent.
+        generate_neuroglancer_multires_mesh(
+            id=1,
+            num_subtask_workers=1,
+            output_path=output_path,
+            lods=[0, 1, 2, 3],
+            original_ext=".ply",
+            lod_0_box_size=np.array([50.0, 50.0, 50.0]),
+        )
+
+        index_file = os.path.join(output_path, "multires", "1.index")
+        with open(index_file, "rb") as f:
+            data = f.read()
+        chunk_shape = np.frombuffer(data, "<f", 3, 0).copy()
+        num_lods = struct.unpack("<I", data[24:28])[0]
+        assert num_lods == 4, f"Expected all 4 LODs preserved, got {num_lods}"
+
+        off = 28 + 4 * num_lods + 12 * num_lods
+        num_frags_per_lod = np.frombuffer(data, "<I", num_lods, off).copy()
+        off += 4 * num_lods
+        nf = num_frags_per_lod[0]
+        positions = np.frombuffer(data, "<I", nf * 3, off).reshape(3, nf).T.copy()
+        listed_extent = (positions.max(axis=0) + 1 - positions.min(axis=0)) * chunk_shape
+
+        from mesh_n_bone.util.mesh_io import mesh_loader
+        verts, _ = mesh_loader(os.path.join(output_path, "mesh_lods", "s0", "1.ply"))
+        mesh_extent = verts.max(axis=0) - verts.min(axis=0)
+
+        # With the bloat bug, listed_extent would be ~8x mesh_extent.
+        # Union-bbox empty placeholders keep it within 2x.
+        assert np.all(listed_extent <= 2.0 * mesh_extent + chunk_shape), (
+            f"Listed-fragment extent {listed_extent} too large for mesh "
+            f"extent {mesh_extent} (chunk_shape {chunk_shape}). "
+            "Empty-placeholder enumeration should be bounded by union "
+            "mesh extent, not octree_unit."
+        )
+
     def test_three_lods_all_valid(self, tmp_output_dir):
         """Three LODs with progressively fewer faces should all be included."""
         output_path = os.path.join(tmp_output_dir, "three_lods")
@@ -452,17 +527,15 @@ class TestLodTruncation:
 class TestTargetFacesPerLod0Chunk:
     """``target_faces_per_lod0_chunk`` overrides the auto-sizing heuristic.
 
-    The default 25k-faces threshold collapses small meshes (under 25k
-    faces) to a single LOD-0 chunk and therefore a single LOD overall.
-    Lowering the threshold should force a multi-chunk grid and keep
-    additional LODs.
+    The default 25k-faces threshold puts small meshes in a single LOD-0
+    chunk; lowering the threshold forces a multi-chunk grid. Either way,
+    decimated LODs are preserved when their mesh files exist.
     """
 
-    def test_low_threshold_keeps_multiple_lods(self, multires_mesh_dir):
+    def test_low_threshold_produces_more_lod0_chunks(self, multires_mesh_dir):
         # ``multires_mesh_dir`` contains an icosphere (subdivisions=3,
         # 1280 faces at LOD 0) — well below 25k, so the default
-        # heuristic collapses it to 1 LOD even though both LOD files
-        # exist on disk.
+        # heuristic puts the whole mesh in 1 LOD-0 chunk.
         output_path = multires_mesh_dir
 
         generate_neuroglancer_multires_mesh(
@@ -473,11 +546,14 @@ class TestTargetFacesPerLod0Chunk:
             original_ext=".ply",
         )
         with open(os.path.join(output_path, "multires", "1.index"), "rb") as f:
-            default_num_lods = struct.unpack("<I", f.read()[24:28])[0]
-        assert default_num_lods == 1, (
-            f"Default 25k-face heuristic should collapse a 1280-face mesh "
-            f"to 1 LOD; got {default_num_lods}."
-        )
+            default_data = f.read()
+        default_num_lods = struct.unpack("<I", default_data[24:28])[0]
+        # LOD-0 chunk count under default heuristic: read num_fragments_per_lod
+        # entry for LOD 0.
+        default_off = 28 + 4 * default_num_lods + 12 * default_num_lods
+        default_num_frags_lod0 = struct.unpack(
+            "<I", default_data[default_off:default_off + 4],
+        )[0]
 
         # Force the heuristic to chunk by setting the per-chunk target
         # well below the LOD-0 face count.
@@ -490,10 +566,17 @@ class TestTargetFacesPerLod0Chunk:
             target_faces_per_lod0_chunk=100,
         )
         with open(os.path.join(output_path, "multires", "1.index"), "rb") as f:
-            tuned_num_lods = struct.unpack("<I", f.read()[24:28])[0]
-        assert tuned_num_lods > default_num_lods, (
-            "Lowering target_faces_per_lod0_chunk should produce more LODs"
-            f" than the default; got {tuned_num_lods} vs {default_num_lods}."
+            tuned_data = f.read()
+        tuned_num_lods = struct.unpack("<I", tuned_data[24:28])[0]
+        tuned_off = 28 + 4 * tuned_num_lods + 12 * tuned_num_lods
+        tuned_num_frags_lod0 = struct.unpack(
+            "<I", tuned_data[tuned_off:tuned_off + 4],
+        )[0]
+
+        assert tuned_num_frags_lod0 > default_num_frags_lod0, (
+            "Lowering target_faces_per_lod0_chunk should produce more "
+            f"LOD-0 fragments than the default; got {tuned_num_frags_lod0}"
+            f" vs {default_num_frags_lod0}."
         )
 
 


### PR DESCRIPTION
@stuarteberg
Clean rewrite of PR #19 + #20 with only the necessary commits.

## Summary

Four commits, no dead-end iterations:

1. **`c132ca9` — Nested zarr containers.** `split_dataset_path` was using `str.split` and discarding everything past the second `.zarr`/`.n5` occurrence. Switch to `rsplit` so the rightmost extension marks the container boundary. Fixes paths like `outer.zarr/inner.zarr/multiscale/s0`.

2. **`2d8cbb5` — Snap chunk-boundary vertices before Draco quantization.** The slicer can emit boundary vertices a hair off the chunk-plane in float64. Without snapping, the same conceptual vertex in two adjacent chunks could round to two different lattice positions, decoding to a sub-pixel seam. Snap any local coord within half a quantization step of 0 or `current_box_size` to the boundary before the round.

3. **`ec59cab` — Cap chunk_shape so the root chunk fits the mesh + union-bbox empty placeholders.** Two related writer fixes:
   - Auto-heuristic now enforces `num_chunks_per_axis ≥ octree_unit`, so the LOD-K root chunk's world extent is bounded by the actual mesh extent. NG's per-chunk LOD-select gate fires properly and the persistent always-rendered coarsest LOD goes away.
   - Empty-fragment placeholders are emitted bounded by the union of every LOD's vertex bbox (in LOD-0 chunk-index units). Tells NG which sub-chunks are genuinely empty so cross-LOD coverage is clean. Vertex AABB == triangle AABB for triangular faces, so unioning vertex bboxes is face-correct.

4. **`d8200ac` — Bump version to 0.1.4.**

## Replaces

- Closes #19 (zarr fix is included; LOD-cap commit dropped because the chunk_shape cap supersedes it).
- Closes #20 (squashed to its essential commits — drops the experimental "strip empty placeholders" iteration that produced LOD overlap).

## Tests

219 tests pass (`pytest tests/ -q --ignore=tests/test_integration_skeleton.py`). New regression test `test_listed_grid_stays_tight_with_many_lods` verifies the empty-placeholder envelope tracks mesh extent rather than `octree_unit^3`.