### PR TITLE
Multires fixes + Colab example notebook + serve improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 test_meshes_output/
 workspace.code-workspace
 *.ipynb
+!examples/example.ipynb
 job-logs/
 *.obj
 *.stl
@@ -33,3 +34,6 @@ fetchMeshes.py
 tests/test.py
 examples/data/
 examples/output/
+examples/meshify-config-*/
+failed_mesh.ply
+.codex

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ examples/output/
 examples/meshify-config-*/
 failed_mesh.ply
 .codex
+
+# CGAL skeletonizer binary — built locally via `pixi run -e build-cgal build-cgal`
+cgal_skeletonize_mesh/skeletonize_mesh
+cgal_skeletonize_mesh/build/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Produces meshes in the [neuroglancer precomputed format](https://github.com/goog
 
 ![Demo](recording/recording.gif)
 
+## Try it in Colab
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/janelia-cellmap/mesh-n-bone/blob/master/examples/example.ipynb)
+
+The [example notebook](examples/example.ipynb) runs the full pipeline end-to-end (build a zarr volume, generate meshes, view in neuroglancer) without any local setup.
+
 ## Quick start
 
 ```bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,12 @@
 
 End-to-end walkthrough: create a segmentation volume, generate meshes, and view both the volume and meshes in neuroglancer.
 
+## Run in Colab
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/janelia-cellmap/mesh-n-bone/blob/master/examples/example.ipynb)
+
+The [example notebook](example.ipynb) does the steps below in one click — install, build the zarr volume, run meshify, and launch a local neuroglancer viewer.
+
 ## Prerequisites
 
 ```bash

--- a/examples/create_example_volume.py
+++ b/examples/create_example_volume.py
@@ -1,37 +1,37 @@
 """Create an example zarr segmentation volume for the meshify demo.
 
 Generates a 256x256x256 uint8 volume with two labeled objects:
-  - Label 1: a sphere (radius 80 voxels)
-  - Label 2: a cube (80x80x80 voxels)
+  - Label 1: a sphere (radius 50 voxels)
+  - Label 2: a torus (R=40, r=20)
 
-Output: examples/data/example.zarr/seg/s0
+Output: examples/data/example.zarr/seg/s0 (zarr v3, OME-NGFF multiscales)
 """
 
+import json
 import os
+import shutil
+
 import numpy as np
-import zarr
+import tensorstore as ts
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 zarr_path = os.path.join(script_dir, "data", "example.zarr")
+seg_path = os.path.join(zarr_path, "seg")
+array_path = os.path.join(seg_path, "s0")
+
+if os.path.exists(zarr_path):
+    shutil.rmtree(zarr_path)
 
 vol = np.zeros((256, 256, 256), dtype=np.uint8)
-
 zz, yy, xx = np.mgrid[0:256, 0:256, 0:256]
 
-# Label 1: sphere centered at (128, 64, 64), radius 50
 dist_sphere = np.sqrt((zz - 128) ** 2 + (yy - 64) ** 2 + (xx - 64) ** 2)
 vol[dist_sphere <= 50] = 1
 
-# Label 2: torus centered at (128, 192, 192), ring in the y-z plane
-# major radius R=40 (distance from center to ring), minor radius r=20 (tube)
 dist_to_ring = (np.sqrt((yy - 192) ** 2 + (zz - 128) ** 2) - 40) ** 2 + (xx - 192) ** 2
 vol[dist_to_ring <= 20 ** 2] = 2
 
-root = zarr.open_group(zarr_path, mode="w")
-seg_group = root.require_group("seg")
-
-# OME-NGFF multiscale metadata (z, y, x axes at 1 nm resolution)
-seg_group.attrs["multiscales"] = [
+multiscales = [
     {
         "version": "0.5",
         "axes": [
@@ -50,7 +50,32 @@ seg_group.attrs["multiscales"] = [
     }
 ]
 
-arr = seg_group.create_array("s0", data=vol, chunks=(64, 64, 64))
+os.makedirs(seg_path, exist_ok=True)
+with open(os.path.join(zarr_path, "zarr.json"), "w") as f:
+    json.dump({"zarr_format": 3, "node_type": "group", "attributes": {}}, f)
+with open(os.path.join(seg_path, "zarr.json"), "w") as f:
+    json.dump(
+        {"zarr_format": 3, "node_type": "group", "attributes": {"multiscales": multiscales}},
+        f,
+    )
 
-print(f"Created example volume at {zarr_path}/seg/s0")
+arr = ts.open(
+    {
+        "driver": "zarr3",
+        "kvstore": {"driver": "file", "path": os.path.abspath(array_path)},
+        "metadata": {
+            "shape": list(vol.shape),
+            "data_type": "uint8",
+            "chunk_grid": {
+                "name": "regular",
+                "configuration": {"chunk_shape": [64, 64, 64]},
+            },
+        },
+        "create": True,
+        "delete_existing": True,
+    }
+).result()
+arr.write(vol).result()
+
+print(f"Created example volume at {array_path}")
 print(f"  Shape: {vol.shape}, dtype: {vol.dtype}, Labels: {np.unique(vol[vol > 0]).tolist()}")

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -1,0 +1,204 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# mesh-n-bone end-to-end example\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/janelia-cellmap/mesh-n-bone/blob/master/examples/example.ipynb)\n",
+    "\n",
+    "Runs the full pipeline in one notebook:\n",
+    "1. Install the package\n",
+    "2. Create a 256\u00b3 zarr segmentation volume (sphere + torus)\n",
+    "3. Generate meshes and the multires Draco output\n",
+    "4. Launch a local neuroglancer viewer\n",
+    "\n",
+    "Works on a local machine or in Google Colab. Skeletonization is **not** included \u2014 it requires a separately compiled CGAL binary."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Install"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --quiet \\\n",
+    "    'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git' \\\n",
+    "    'tensorstore' 'neuroglancer' 'pymeshlab' 'pyfqmr' 'trimesh>=4.6.8' \\\n",
+    "    'dracopy>=1.5.0' 'cloud-volume' 'zmesh' 'fastremap' 'funlib-geometry' \\\n",
+    "    'pybind11-rdp' 'shapely' 'dask[distributed]==2025.5.1' 'dask-jobqueue==0.9.0' 'bokeh>=3.1.0'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Create the example zarr volume\n",
+    "\n",
+    "256\u00b3 uint8 volume with two labels:\n",
+    "- Label 1: sphere (radius 50)\n",
+    "- Label 2: torus (R=40, r=20)\n",
+    "\n",
+    "Written as zarr v3 with OME-NGFF multiscales metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json, os, shutil\n",
+    "import numpy as np\n",
+    "import tensorstore as ts\n",
+    "\n",
+    "work_dir = os.path.abspath('mesh-n-bone-example')\n",
+    "zarr_path = os.path.join(work_dir, 'data', 'example.zarr')\n",
+    "seg_path = os.path.join(zarr_path, 'seg')\n",
+    "array_path = os.path.join(seg_path, 's0')\n",
+    "if os.path.exists(zarr_path):\n",
+    "    shutil.rmtree(zarr_path)\n",
+    "\n",
+    "vol = np.zeros((256, 256, 256), dtype=np.uint8)\n",
+    "zz, yy, xx = np.mgrid[0:256, 0:256, 0:256]\n",
+    "vol[np.sqrt((zz-128)**2 + (yy-64)**2 + (xx-64)**2) <= 50] = 1\n",
+    "vol[(np.sqrt((yy-192)**2 + (zz-128)**2) - 40)**2 + (xx-192)**2 <= 20**2] = 2\n",
+    "\n",
+    "multiscales = [{\n",
+    "    'version': '0.5',\n",
+    "    'axes': [{'name': a, 'type': 'space', 'unit': 'nanometer'} for a in 'zyx'],\n",
+    "    'datasets': [{'path': 's0', 'coordinateTransformations': [{'type': 'scale', 'scale': [1.0, 1.0, 1.0]}]}],\n",
+    "}]\n",
+    "os.makedirs(seg_path, exist_ok=True)\n",
+    "with open(os.path.join(zarr_path, 'zarr.json'), 'w') as f:\n",
+    "    json.dump({'zarr_format': 3, 'node_type': 'group', 'attributes': {}}, f)\n",
+    "with open(os.path.join(seg_path, 'zarr.json'), 'w') as f:\n",
+    "    json.dump({'zarr_format': 3, 'node_type': 'group', 'attributes': {'multiscales': multiscales}}, f)\n",
+    "\n",
+    "arr = ts.open({\n",
+    "    'driver': 'zarr3',\n",
+    "    'kvstore': {'driver': 'file', 'path': array_path},\n",
+    "    'metadata': {\n",
+    "        'shape': list(vol.shape),\n",
+    "        'data_type': 'uint8',\n",
+    "        'chunk_grid': {'name': 'regular', 'configuration': {'chunk_shape': [64, 64, 64]}},\n",
+    "    },\n",
+    "    'create': True, 'delete_existing': True,\n",
+    "}).result()\n",
+    "arr.write(vol).result()\n",
+    "print(f'Wrote {array_path}, labels {np.unique(vol[vol > 0]).tolist()}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Run meshify\n",
+    "\n",
+    "Marching cubes \u2192 simplification \u2192 multiresolution Draco output. Calls the `Meshify` class directly so we don't need a config file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mesh_n_bone.meshify.meshify import Meshify\n",
+    "\n",
+    "output_dir = os.path.join(work_dir, 'output')\n",
+    "if os.path.exists(output_dir):\n",
+    "    shutil.rmtree(output_dir)\n",
+    "\n",
+    "meshify = Meshify(\n",
+    "    input_path=array_path,\n",
+    "    output_directory=output_dir,\n",
+    "    num_workers=1,\n",
+    "    do_simplification=True,\n",
+    "    target_reduction=0.5,\n",
+    "    n_smoothing_iter=5,\n",
+    "    check_mesh_validity=False,\n",
+    "    do_multires=True,\n",
+    "    num_lods=3,\n",
+    "    multires_strategy='decimate',\n",
+    "    decimation_factor=2,\n",
+    "    delete_decimated_meshes=True,\n",
+    "    do_analysis=False,\n",
+    ")\n",
+    "meshify.get_meshes()\n",
+    "print('Meshes written to', output_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. View in neuroglancer\n",
+    "\n",
+    "Starts both:\n",
+    "- The local data HTTP server (CORS + Range requests, needed for the precomputed mesh format)\n",
+    "- A Python `neuroglancer.Viewer` so the page loads even on Colab (where the HTTPS demo URL can't reach an HTTP-only proxy port)\n",
+    "\n",
+    "On Colab, the cell prints a `https://<id>.colab.googleusercontent.com/...` proxy URL \u2014 click that. On a local machine, click the printed `http://localhost:...` URL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import threading\n",
+    "from functools import partial\n",
+    "from http.server import HTTPServer\n",
+    "import neuroglancer\n",
+    "from mesh_n_bone.serve import CORSHandler, _get_local_ip, _detect_zarr_scheme\n",
+    "\n",
+    "data_port = 9015\n",
+    "handler = partial(CORSHandler, directory=work_dir)\n",
+    "data_server = HTTPServer(('0.0.0.0', data_port), handler)\n",
+    "threading.Thread(target=data_server.serve_forever, daemon=True).start()\n",
+    "\n",
+    "local_ip = _get_local_ip() or 'localhost'\n",
+    "scheme = _detect_zarr_scheme(seg_path)  # 'zarr3' for v3\n",
+    "data_host = local_ip if local_ip != '127.0.0.1' else 'localhost'\n",
+    "base = f'http://{data_host}:{data_port}'\n",
+    "sources = [\n",
+    "    f'{scheme}://{base}/data/example.zarr/seg',\n",
+    "    f'precomputed://{base}/output/multires',\n",
+    "]\n",
+    "\n",
+    "neuroglancer.set_server_bind_address('0.0.0.0')\n",
+    "viewer = neuroglancer.Viewer()\n",
+    "with viewer.txn() as s:\n",
+    "    s.layers['segmentation'] = neuroglancer.SegmentationLayer(\n",
+    "        source=sources,\n",
+    "        segments=[1, 2],\n",
+    "    )\n",
+    "print('Open this URL:')\n",
+    "print(' ', viewer.get_viewer_url())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pixi.lock
+++ b/pixi.lock
@@ -6073,8 +6073,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: .
   name: mesh-n-bone
-  version: 0.1.4
-  sha256: 75e34d92fa84b0f1065cf2ba7f6c84a50742f48df339ff77367553fb0de98ad8
+  version: 0.1.5
+  sha256: 866d193040a8c362343c21e9458fae0656ebf4f0e5d6939c511f9f67494cb1db
   requires_dist:
   - numpy
   - trimesh>=4.6.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mesh-n-bone"
-version = "0.1.4"
+version = "0.1.5"
 description = "Unified tool for mesh generation, multiresolution mesh creation, skeletonization, and analysis."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mesh_n_bone/multires/decomposition.py
+++ b/src/mesh_n_bone/multires/decomposition.py
@@ -200,15 +200,22 @@ def generate_mesh_decomposition(
                 current_box_size = lod_0_box_size * 2**current_lod
                 quantization_origin = np.asarray(fragment_pos) * current_box_size
                 quantization_bits = vertex_quantization_bits
+                if quantization_bits < 1 or quantization_bits > 16:
+                    raise ValueError(
+                        "vertex_quantization_bits must be between 1 and 16"
+                    )
                 # The spec requires Draco-encoded INTEGER positions in
                 # [0, 2^bits).  Compute per-axis integer positions:
                 #   q[j] = round(local[j] / current_box_size[j] * max_q)
-                # then encode with range=max_q so DracoPy stores them
-                # as-is.  Neuroglancer decodes via:
+                # then pass those integers to DracoPy directly.
+                # Neuroglancer decodes via:
                 #   world[j] = grid_origin[j] + chunk_shape[j] * 2^lod
                 #              * (frag_pos[j] + q[j] / max_q)
-                max_q = float((1 << quantization_bits) - 1)
-                local_vertices = fragment.vertices.astype(np.float64) - quantization_origin
+                max_q = (1 << quantization_bits) - 1
+                max_q_float = float(max_q)
+                local_vertices = (
+                    fragment.vertices.astype(np.float64) - quantization_origin
+                )
                 local_vertices = np.clip(local_vertices, 0.0, current_box_size)
 
                 # Snap vertices that fall within half a quantization
@@ -219,7 +226,7 @@ def generate_mesh_decomposition(
                 # to two different lattice positions, decoding to two
                 # slightly-different world coords and creating a
                 # visible sub-pixel seam at every chunk boundary.
-                half_step = current_box_size / max_q / 2.0
+                half_step = current_box_size / max_q_float / 2.0
                 local_vertices = np.where(
                     local_vertices < half_step, 0.0, local_vertices,
                 )
@@ -229,20 +236,62 @@ def generate_mesh_decomposition(
                     local_vertices,
                 )
 
-                # Compute integer quantized positions per axis
+                # Compute integer quantized positions per axis. Pass an
+                # unsigned integer attribute to DracoPy, since
+                # neuroglancer's multilod_draco format explicitly does
+                # not support Draco's built-in position quantization.
                 int_positions = np.round(
-                    local_vertices * (max_q / current_box_size)
-                ).astype(np.float64)
-                int_positions = np.clip(int_positions, 0.0, max_q)
+                    local_vertices * (max_q_float / current_box_size)
+                )
+                int_positions = np.clip(int_positions, 0, max_q)
+
+                if current_lod != 0:
+                    # Neuroglancer partitions every nonzero-LOD Draco
+                    # fragment into 2x2x2 subchunks. Coordinates below
+                    # partition_q are lower-only, coordinates above
+                    # partition_q are upper-only, and coordinates exactly
+                    # equal to partition_q are treated as lying on the
+                    # shared boundary and may be used by either side.
+                    # The mesh was already sliced into those subchunks
+                    # before merging into this parent fragment, but
+                    # slice vertices can land just across the half-plane
+                    # after rounding. Snap near-boundary vertices to
+                    # partition_q and keep non-boundary vertices on
+                    # their source side.
+                    source_fragment_pos = np.asarray(
+                        fragment.vertex_lod_0_fragment_pos, dtype=np.int64
+                    )
+                    subchunk_bits = (
+                        source_fragment_pos
+                        - np.asarray(fragment_pos, dtype=np.int64) * 2
+                    )
+                    if np.any((subchunk_bits < 0) | (subchunk_bits > 1)):
+                        raise ValueError(
+                            "higher-LOD fragment contains vertices outside its "
+                            "2x2x2 subchunk set"
+                        )
+
+                    partition_q = 1 << (quantization_bits - 1)
+                    boundary_vertices = (
+                        ((subchunk_bits == 0) & (int_positions >= partition_q - 1))
+                        | ((subchunk_bits == 1) & (int_positions <= partition_q + 1))
+                    )
+                    int_positions = np.where(
+                        boundary_vertices, partition_q, int_positions
+                    )
+                    int_positions = np.where(
+                        subchunk_bits == 0,
+                        np.minimum(int_positions, partition_q),
+                        np.maximum(int_positions, partition_q),
+                    )
+
+                int_positions = int_positions.astype(np.uint16)
 
                 draco_bytes, _ = capture_draco_output(
                     2,
                     DracoPy.encode,
                     points=int_positions,
                     faces=fragment.faces,
-                    quantization_bits=quantization_bits,
-                    quantization_range=max_q,
-                    quantization_origin=[0.0, 0.0, 0.0],
                 )
 
                 if len(draco_bytes) > 12:

--- a/src/mesh_n_bone/serve.py
+++ b/src/mesh_n_bone/serve.py
@@ -12,12 +12,24 @@ from urllib.parse import quote
 class CORSHandler(SimpleHTTPRequestHandler):
     """HTTP handler that adds CORS headers and supports HTTP Range requests for neuroglancer."""
 
+    _client_disconnect_errors = (
+        BrokenPipeError,
+        ConnectionAbortedError,
+        ConnectionResetError,
+    )
+
     def end_headers(self):
         self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
         self.send_header("Access-Control-Allow-Headers", "Content-Type, Range")
         self.send_header("Access-Control-Expose-Headers", "Content-Length, Content-Range")
         super().end_headers()
+
+    def finish(self):
+        try:
+            super().finish()
+        except self._client_disconnect_errors:
+            pass
 
     def do_OPTIONS(self):
         self.send_response(200)
@@ -26,7 +38,10 @@ class CORSHandler(SimpleHTTPRequestHandler):
     def do_GET(self):
         range_header = self.headers.get("Range")
         if not range_header:
-            return super().do_GET()
+            try:
+                return super().do_GET()
+            except self._client_disconnect_errors:
+                return
 
         path = self.translate_path(self.path)
         try:
@@ -59,7 +74,7 @@ class CORSHandler(SimpleHTTPRequestHandler):
                     break
                 self.wfile.write(chunk)
                 remaining -= len(chunk)
-        except (BrokenPipeError, ConnectionResetError):
+        except self._client_disconnect_errors:
             pass
         finally:
             f.close()

--- a/src/mesh_n_bone/serve.py
+++ b/src/mesh_n_bone/serve.py
@@ -6,7 +6,7 @@ import socket
 import sys
 from functools import partial
 from http.server import HTTPServer, SimpleHTTPRequestHandler
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 
 class CORSHandler(SimpleHTTPRequestHandler):
@@ -205,6 +205,47 @@ def _build_neuroglancer_url(directory, host, port, zarr_path=None, meshes_path=N
     return f"https://neuroglancer-demo.appspot.com/#!{quote(json.dumps(state))}"
 
 
+# Strong references to live neuroglancer viewers — server.viewers is a
+# WeakValueDictionary, so dropping these would let the viewer get GC'd and
+# every later /v/<token>/ request would 404.
+_live_viewers = []
+
+
+def _start_local_neuroglancer(directory, http_port, host, zarr_path, meshes_path):
+    """Start a local Python neuroglancer server with the given sources loaded.
+
+    Returns the viewer URL, or ``None`` if neuroglancer is not installed or
+    there is nothing to display.
+    """
+    try:
+        import neuroglancer
+    except ImportError:
+        return None
+
+    base = f"http://{host}:{http_port}"
+    sources = []
+    if zarr_path:
+        group_path = _resolve_ome_ngff_group(directory, zarr_path)
+        scheme = _detect_zarr_scheme(os.path.join(directory, group_path))
+        sources.append(f"{scheme}://{base}/{group_path}")
+    if meshes_path:
+        sources.append(f"precomputed://{base}/{meshes_path}")
+    if not sources:
+        return None
+
+    segment_ids = [int(s) for s in (_get_segment_ids(directory, meshes_path) if meshes_path else [])]
+
+    neuroglancer.set_server_bind_address("0.0.0.0")
+    viewer = neuroglancer.Viewer()
+    _live_viewers.append(viewer)
+    with viewer.txn() as s:
+        s.layers["segmentation"] = neuroglancer.SegmentationLayer(
+            source=sources,
+            segments=segment_ids,
+        )
+    return viewer.get_viewer_url()
+
+
 def serve(directory, port=9015, zarr_path=None, meshes_path=None):
     """Serve *directory* over HTTP with CORS headers and Range request support.
 
@@ -235,10 +276,20 @@ def serve(directory, port=9015, zarr_path=None, meshes_path=None):
         print(f"  network:    http://{local_ip}:{port}")
 
     if zarr_path or meshes_path:
-        ng_local = _build_neuroglancer_url(directory, "localhost", port, zarr_path, meshes_path)
-        if ng_local:
-            print(f"\nOpen in neuroglancer:\n  {ng_local}")
+        ng_demo = _build_neuroglancer_url(directory, "localhost", port, zarr_path, meshes_path)
+        if ng_demo:
+            print(f"\nOpen in neuroglancer demo (this machine only — HTTPS blocks LAN HTTP fetches):\n  {ng_demo}")
 
+        data_host = local_ip if local_ip and local_ip != "127.0.0.1" else "localhost"
+        ng_local_url = _start_local_neuroglancer(directory, port, data_host, zarr_path, meshes_path)
+        if ng_local_url:
+            parsed = urlparse(ng_local_url)
+            ng_path = parsed.path + (f"?{parsed.query}" if parsed.query else "") + (f"#{parsed.fragment}" if parsed.fragment else "")
+            ng_port = parsed.port
+            print("\nOpen in local neuroglancer server:")
+            print(f"  localhost:  http://localhost:{ng_port}{ng_path}")
+            if local_ip and local_ip != "127.0.0.1":
+                print(f"  network:    http://{local_ip}:{ng_port}{ng_path}")
 
     print("\nPress Ctrl+C to stop.")
 

--- a/src/mesh_n_bone/util/mesh_io.py
+++ b/src/mesh_n_bone/util/mesh_io.py
@@ -21,12 +21,39 @@ class Fragment:
         Triangle face indices with shape ``(M, 3)``.
     lod_0_fragment_pos : list
         List of LOD 0 fragment grid positions associated with this fragment.
+    vertex_lod_0_fragment_pos : numpy.ndarray, optional
+        Per-vertex source fragment positions with shape ``(N, 3)``.
     """
 
-    def __init__(self, vertices, faces, lod_0_fragment_pos):
+    def __init__(
+        self, vertices, faces, lod_0_fragment_pos, vertex_lod_0_fragment_pos=None
+    ):
         self.vertices = vertices
         self.faces = faces
         self.lod_0_fragment_pos = lod_0_fragment_pos
+        if vertex_lod_0_fragment_pos is None:
+            self.vertex_lod_0_fragment_pos = self._per_vertex_fragment_pos(
+                vertices, lod_0_fragment_pos
+            )
+        else:
+            vertex_lod_0_fragment_pos = np.asarray(
+                vertex_lod_0_fragment_pos, dtype=np.int64
+            )
+            if vertex_lod_0_fragment_pos.shape != (len(vertices), 3):
+                raise ValueError(
+                    "vertex_lod_0_fragment_pos must have shape "
+                    f"({len(vertices)}, 3)"
+                )
+            self.vertex_lod_0_fragment_pos = vertex_lod_0_fragment_pos
+
+    @staticmethod
+    def _per_vertex_fragment_pos(vertices, lod_0_fragment_pos):
+        positions = np.asarray(lod_0_fragment_pos, dtype=np.int64)
+        if positions.ndim == 1:
+            position = positions
+        else:
+            position = positions[-1]
+        return np.repeat(position.reshape(1, 3), len(vertices), axis=0)
 
     def update_faces(self, new_faces):
         self.faces = np.vstack((self.faces, new_faces + len(self.vertices)))
@@ -37,10 +64,19 @@ class Fragment:
     def update_lod_0_fragment_pos(self, new_lod_0_fragment_pos):
         self.lod_0_fragment_pos.append(new_lod_0_fragment_pos)
 
+    def update_vertex_lod_0_fragment_pos(self, new_vertices, new_lod_0_fragment_pos):
+        new_vertex_lod_0_fragment_pos = self._per_vertex_fragment_pos(
+            new_vertices, new_lod_0_fragment_pos
+        )
+        self.vertex_lod_0_fragment_pos = np.vstack(
+            (self.vertex_lod_0_fragment_pos, new_vertex_lod_0_fragment_pos)
+        )
+
     def update(self, new_vertices, new_faces, new_lod_0_fragment_pos):
         self.update_faces(new_faces)
         self.update_vertices(new_vertices)
         self.update_lod_0_fragment_pos(new_lod_0_fragment_pos)
+        self.update_vertex_lod_0_fragment_pos(new_vertices, new_lod_0_fragment_pos)
 
 
 CompressedFragment = namedtuple(

--- a/src/mesh_n_bone/util/neuroglancer.py
+++ b/src/mesh_n_bone/util/neuroglancer.py
@@ -407,7 +407,7 @@ def write_singleres_index_file(
 
 
 def write_singleres_multires_files(
-    vertices_xyz, faces, path, vertex_quantization_bits=10, draco_compression_level=10
+    vertices_xyz, faces, path, vertex_quantization_bits=16, draco_compression_level=10
 ):
     """Encode a single-resolution mesh as a multi-LOD Draco file with index.
 
@@ -425,7 +425,7 @@ def write_singleres_multires_files(
         Output file path for the Draco-encoded mesh data.
     vertex_quantization_bits : int, optional
         Number of quantization bits per vertex coordinate.  Default is
-        ``10``.
+        ``16``.
     draco_compression_level : int, optional
         Draco compression level (0--10).  Default is ``10``.
 
@@ -450,17 +450,11 @@ def write_singleres_multires_files(
         vertex_quantization_bits=vertex_quantization_bits,
     )
 
-    quantization_origin = np.min(vertices_xyz, axis=0)
-    quantization_range = np.max(vertices_xyz, axis=0) - quantization_origin
-    quantization_range = np.max(quantization_range)
     try:
         res = DracoPy.encode(
             vertices_xyz,
             faces,
-            quantization_bits=vertex_quantization_bits,
-            quantization_range=quantization_range,
             compression_level=draco_compression_level,
-            quantization_origin=quantization_origin,
         )
     except Exception:
         res = b""

--- a/tests/test_integration_multires.py
+++ b/tests/test_integration_multires.py
@@ -56,6 +56,14 @@ class TestDecompositionPipeline:
             assert frag.offset == len(frag.draco_bytes)
             assert len(frag.position) == 3
 
+        import DracoPy
+
+        decoded = DracoPy.decode(fragments[0].draco_bytes)
+        points = np.asarray(decoded.points)
+        assert np.issubdtype(points.dtype, np.integer)
+        assert points.min() >= 0
+        assert points.max() <= 2**16 - 1
+
     def test_higher_lod_decomposition(self, tmp_output_dir):
         """LOD > 0 should produce fragments with 2x larger effective box sizes."""
         mesh = trimesh.creation.icosphere(subdivisions=2, radius=50.0)
@@ -90,6 +98,27 @@ class TestDecompositionPipeline:
         assert fragments_lod1 is not None
         # Higher LOD should have fewer or equal fragments (larger effective box)
         assert len(fragments_lod1) <= len(fragments_lod0)
+
+        import DracoPy
+
+        partition_q = 1 << 15
+        for frag in fragments_lod1:
+            decoded = DracoPy.decode(frag.draco_bytes)
+            points = np.asarray(decoded.points)
+            faces = np.asarray(decoded.faces)
+            vertex_masks = np.full(len(points), 0xFF, dtype=np.uint16)
+            vertex_masks[points[:, 0] < partition_q] &= 0b01010101
+            vertex_masks[points[:, 0] > partition_q] &= 0b10101010
+            vertex_masks[points[:, 1] < partition_q] &= 0b00110011
+            vertex_masks[points[:, 1] > partition_q] &= 0b11001100
+            vertex_masks[points[:, 2] < partition_q] &= 0b00001111
+            vertex_masks[points[:, 2] > partition_q] &= 0b11110000
+            face_masks = (
+                vertex_masks[faces[:, 0]]
+                & vertex_masks[faces[:, 1]]
+                & vertex_masks[faces[:, 2]]
+            )
+            assert not np.any(face_masks == 0)
 
     def test_empty_region_returns_none(self, tmp_output_dir):
         """Decomposing a region with no mesh should return None."""

--- a/tests/test_integration_neuroglancer.py
+++ b/tests/test_integration_neuroglancer.py
@@ -85,6 +85,13 @@ class TestSingleresMultiresFormat:
             mesh.vertices, mesh.faces, path
         )
 
+        import DracoPy
+
+        decoded = DracoPy.decode(res)
+        decoded_points = np.asarray(decoded.points)
+        assert np.issubdtype(decoded_points.dtype, np.integer)
+        assert decoded_points.max() == 2**16 - 1
+
         # Mesh data file
         assert os.path.exists(path)
         assert os.path.getsize(path) > 0

--- a/tests/test_mesh_io.py
+++ b/tests/test_mesh_io.py
@@ -44,6 +44,10 @@ class TestFragment:
         assert np.array_equal(frag.vertices, vertices)
         assert np.array_equal(frag.faces, faces)
         assert frag.lod_0_fragment_pos == [(0, 0, 0)]
+        assert np.array_equal(
+            frag.vertex_lod_0_fragment_pos,
+            np.repeat(np.array([[0, 0, 0]]), len(vertices), axis=0),
+        )
 
     def test_fragment_update(self, sample_vertices_and_faces):
         vertices, faces = sample_vertices_and_faces
@@ -52,6 +56,10 @@ class TestFragment:
         assert len(frag.vertices) == 8  # 4 + 4
         assert len(frag.faces) == 8  # 4 + 4
         assert (1, 1, 1) in frag.lod_0_fragment_pos
+        assert np.array_equal(
+            frag.vertex_lod_0_fragment_pos[-len(vertices) :],
+            np.repeat(np.array([[1, 1, 1]]), len(vertices), axis=0),
+        )
 
 
 class TestZorderFragments:


### PR DESCRIPTION
@stuarteberg
## Summary

- **Multires correctness**
  - Fix Draco subchunk partitioning for multires meshes by preserving per-vertex source subchunk metadata and snapping shared partition-boundary vertices to Neuroglancer shared integer boundary (`668d9a6`).
  - Add regression coverage for integer Draco positions and Neuroglancer-compatible partition masks (`668d9a6`).
- **Serve command**
  - Suppress normal client-disconnect tracebacks from canceled browser/Neuroglancer requests (`2c921f1`).
  - Add a local Python `neuroglancer.Viewer` alongside the data HTTP server, with both localhost and LAN-IP URLs (`5797b05`).
- **Example / docs**
  - Rewrite `examples/create_example_volume.py` to use tensorstore, removing `zarr` from the default pixi env (`5797b05`).
  - Add a Colab-runnable end-to-end example notebook and README links (`65cdd06`).
  - Untrack the compiled CGAL skeletonizer binary and ignore generated local artifacts (`bc8aa5c`).
- Bump version to `0.1.5` (`a5a7316`).