### PR TITLE
Simplify example notebook install

### DIFF
--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -30,11 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --quiet \\\n",
-    "    'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git' \\\n",
-    "    'tensorstore' 'neuroglancer' 'pymeshlab' 'pyfqmr' 'trimesh>=4.6.8' \\\n",
-    "    'dracopy>=1.5.0' 'cloud-volume' 'zmesh' 'fastremap' 'funlib-geometry' \\\n",
-    "    'pybind11-rdp' 'shapely' 'dask[distributed]==2025.5.1' 'dask-jobqueue==0.9.0' 'bokeh>=3.1.0'"
+    "%pip install --quiet 'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git'"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- Simplify the Colab example install cell to install `mesh-n-bone` directly from GitHub.
- Rely on `pyproject.toml` package metadata for dependencies instead of listing the same packages manually in the notebook.
