### PR TITLE
Add HTTP(S) URL support for zarr/n5 inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ mesh-n-bone <command> [options]
 mesh-n-bone meshify CONFIG_PATH -n NUM_WORKERS [--roi begin_z,begin_y,begin_x,end_z,end_y,end_x]
 ```
 
-Reads a `.zarr` or `.n5` segmentation volume, runs marching cubes per chunk, assembles across chunk boundaries (with boundary deduplication), optionally simplifies and smooths, and writes output as PLY or neuroglancer format.
+Reads a local or HTTP(S) `.zarr` / `.n5` segmentation volume, runs marching cubes per chunk, assembles across chunk boundaries (with boundary deduplication), optionally simplifies and smooths, and writes output as PLY or neuroglancer format.
 
 Example meshify `run-config.yaml`:
 
 ```yaml
 # ── Required ──
-input_path: /path/to/segmentation.zarr/s0   # Path to zarr/n5 segmentation dataset
+input_path: /path/to/segmentation.zarr/s0   # Local path or HTTP(S) URL to zarr/n5 dataset
 output_directory: /path/to/output            # Where to write output meshes
 
 # ── All remaining fields are optional ──
@@ -128,6 +128,8 @@ roi:                             # Restrict processing to this subregion
                                  # Boundary edges are preserved during simplification.
                                  # Can also be passed via CLI: --roi z0,y0,x0,z1,y1,x1
 ```
+
+HTTP(S) inputs are read-only and may point directly at an array path even when the served directory does not end in `.zarr` or `.n5`, for example `https://host/files/crop04_AIPv2/seg/s0`. If the URL points at an OME-Zarr multiscales group, meshify opens the first dataset listed in the group metadata.
 
 #### `to-neuroglancer` — Convert existing meshes to neuroglancer multiresolution format
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ roi:                             # Restrict processing to this subregion
                                  # Can also be passed via CLI: --roi z0,y0,x0,z1,y1,x1
 ```
 
-HTTP(S) inputs are read-only and may point directly at an array path even when the served directory does not end in `.zarr` or `.n5`, for example `https://host/files/crop04_AIPv2/seg/s0`. If the URL points at an OME-Zarr multiscales group, meshify opens the first dataset listed in the group metadata.
+`input_path` may be a local path or an HTTP(S) URL (HTTP(S) is read-only). In either case the path can point directly at an array even when no parent directory ends in `.zarr` or `.n5`, for example `/data/crop04_AIPv2/seg/s0` or `https://host/files/crop04_AIPv2/seg/s0`. If the path points at an OME-Zarr multiscales group rather than an array, meshify opens the first dataset listed in the group metadata.
 
 #### `to-neuroglancer` — Convert existing meshes to neuroglancer multiresolution format
 

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -21,8 +21,16 @@ from mesh_n_bone.util.zarr_io import (
     _read_attrs,
     _get_multiscales,
     _extract_ome_scale_translation,
+    _first_multiscales_dataset_path,
+    _path_basename,
+    _path_dirname,
+    _path_join,
 )
-from mesh_n_bone.util.image_data_interface import open_ds_tensorstore, to_ndarray_tensorstore
+from mesh_n_bone.util.image_data_interface import (
+    _detect_zarr_driver,
+    open_ds_tensorstore,
+    to_ndarray_tensorstore,
+)
 from mesh_n_bone.meshify.downsample import (
     downsample_labels_3d_suppress_zero,
     downsample_labels_3d,
@@ -55,21 +63,23 @@ def _read_ome_ngff_transform(input_path):
     size and offset are returned as ``np.ndarray`` for consistency
     with existing callers.
     """
-    for ext in (".zarr", ".n5"):
-        if ext in input_path:
-            parts = input_path.split(ext + "/")
-            zarr_root_path = parts[0] + ext
-            dataset_path = parts[1] if len(parts) > 1 else ""
-            break
+    zarr_root_path, dataset_path = split_dataset_path(input_path)
+    if dataset_path:
+        dataset_name = _path_basename(dataset_path)
+        parent_path = _path_dirname(dataset_path)
+        parent_dir = _path_join(zarr_root_path, parent_path) if parent_path else zarr_root_path
     else:
-        return None, None, None
-
-    dataset_name = os.path.basename(dataset_path)
-    parent_path = os.path.dirname(dataset_path)
-    parent_dir = os.path.join(zarr_root_path, parent_path) if parent_path else zarr_root_path
+        dataset_name = _path_basename(input_path)
+        parent_dir = _path_dirname(input_path)
 
     try:
         parent_attrs = _read_attrs(parent_dir)
+        if not dataset_path:
+            input_attrs = _read_attrs(input_path)
+            selected_dataset_path = _first_multiscales_dataset_path(input_attrs)
+            if selected_dataset_path:
+                parent_attrs = input_attrs
+                dataset_name = selected_dataset_path
         multiscales = _get_multiscales(parent_attrs)
         if not multiscales:
             return None, None, None
@@ -404,8 +414,11 @@ class Meshify:
         self.segmentation_array = open_dataset(filename, dataset_name)
         self.output_directory = output_directory
         self.input_path = input_path
-        self._dataset_path = os.path.join(filename, dataset_name) if dataset_name else filename
-        self._swap_axes = input_path.rfind(".n5") > input_path.rfind(".zarr")
+        self._dataset_path = (
+            getattr(self.segmentation_array, "_dataset_path", None)
+            or (_path_join(filename, dataset_name) if dataset_name else filename)
+        )
+        self._swap_axes = _detect_zarr_driver(self._dataset_path) == "n5"
 
         # Get true (possibly non-integer) voxel size from the underlying data
         self.true_voxel_size = np.array(read_raw_voxel_size(self.segmentation_array))

--- a/src/mesh_n_bone/util/image_data_interface.py
+++ b/src/mesh_n_bone/util/image_data_interface.py
@@ -9,6 +9,12 @@ import numpy as np
 import tensorstore as ts
 from funlib.geometry import Coordinate, Roi
 
+from mesh_n_bone.util.zarr_io import (
+    _is_http_url,
+    _path_join,
+    _read_json_file,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,7 +24,7 @@ def _detect_zarr_driver(dataset_path):
     Parameters
     ----------
     dataset_path : str
-        Full filesystem path to the dataset.
+        Full filesystem path or HTTP(S) URL to the dataset.
 
     Returns
     -------
@@ -27,12 +33,16 @@ def _detect_zarr_driver(dataset_path):
     """
     if dataset_path.rfind(".n5") > dataset_path.rfind(".zarr"):
         return "n5"
-    if os.path.exists(os.path.join(dataset_path, "zarr.json")):
+    if _read_json_file(_path_join(dataset_path, "zarr.json")) is not None:
         return "zarr3"
+    if _read_json_file(_path_join(dataset_path, ".zarray")) is not None:
+        return "zarr"
+    if _read_json_file(_path_join(dataset_path, "attributes.json")) is not None:
+        return "n5"
     return "zarr"
 
 
-def open_ds_tensorstore(dataset_path, mode="r"):
+def open_ds_tensorstore(dataset_path, mode="r", filetype=None):
     """Open a zarr/n5 dataset with TensorStore.
 
     Parameters
@@ -47,13 +57,23 @@ def open_ds_tensorstore(dataset_path, mode="r"):
     tensorstore.TensorStore
         Opened dataset handle.
     """
-    filetype = _detect_zarr_driver(dataset_path)
-    spec = {
-        "driver": filetype,
-        "kvstore": {
+    filetype = filetype or _detect_zarr_driver(dataset_path)
+    if _is_http_url(dataset_path):
+        if mode != "r":
+            raise ValueError("HTTP(S) TensorStore datasets are read-only")
+        kvstore = {
+            "driver": "http",
+            "base_url": dataset_path,
+        }
+    else:
+        kvstore = {
             "driver": "file",
             "path": os.path.abspath(dataset_path),
-        },
+        }
+
+    spec = {
+        "driver": filetype,
+        "kvstore": kvstore,
     }
     if mode == "r":
         dataset_future = ts.open(spec, read=True, write=False)

--- a/src/mesh_n_bone/util/zarr_io.py
+++ b/src/mesh_n_bone/util/zarr_io.py
@@ -3,12 +3,48 @@
 import json
 import logging
 import os
+import posixpath
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse, urlunparse
+from urllib.request import Request, urlopen
 
 from funlib.geometry import Coordinate
 
 from mesh_n_bone.util.cellmap_array import CellMapArray
 
 logger = logging.getLogger(__name__)
+
+
+def _is_http_url(path):
+    """Return True if *path* is an HTTP(S) URL."""
+    return urlparse(str(path)).scheme in {"http", "https"}
+
+
+def _path_join(base, path):
+    """Join local filesystem paths or append URL path components."""
+    if not path:
+        return base
+    if _is_http_url(base):
+        parsed = urlparse(base)
+        joined_path = posixpath.join(parsed.path.rstrip("/"), str(path).lstrip("/"))
+        return urlunparse(parsed._replace(path=joined_path))
+    return os.path.join(base, path)
+
+
+def _path_dirname(path):
+    """Return the parent path for local filesystem paths or URLs."""
+    if _is_http_url(path):
+        parsed = urlparse(path)
+        dirname = posixpath.dirname(parsed.path.rstrip("/"))
+        return urlunparse(parsed._replace(path=dirname or "/"))
+    return os.path.dirname(path)
+
+
+def _path_basename(path):
+    """Return the final path component for local filesystem paths or URLs."""
+    if _is_http_url(path):
+        return posixpath.basename(urlparse(path).path.rstrip("/"))
+    return os.path.basename(path)
 
 
 class ArrayMetadata:
@@ -19,20 +55,24 @@ class ArrayMetadata:
     and ``attrs``.
     """
 
-    def __init__(self, shape, dtype, chunks, attrs):
+    def __init__(
+        self, shape, dtype, chunks, attrs, parent_attrs=None, dataset_name=None,
+    ):
         self.shape = shape
         self.dtype = dtype
         self.chunks = chunks
         self.attrs = attrs
+        self.parent_attrs = parent_attrs
+        self.dataset_name = dataset_name
 
 
 def _read_json_file(path):
-    """Read a JSON file from a local path.
+    """Read a JSON file from a local path or HTTP(S) URL.
 
     Parameters
     ----------
     path : str
-        Path to the JSON file.
+        Path or URL to the JSON file.
 
     Returns
     -------
@@ -41,9 +81,21 @@ def _read_json_file(path):
         not valid JSON.
     """
     try:
-        with open(path) as f:
-            return json.load(f)
-    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        if _is_http_url(path):
+            request = Request(path, headers={"Accept": "application/json"})
+            with urlopen(request, timeout=10) as f:
+                return json.load(f)
+        else:
+            with open(path) as f:
+                return json.load(f)
+    except (
+        FileNotFoundError,
+        OSError,
+        HTTPError,
+        URLError,
+        TimeoutError,
+        json.JSONDecodeError,
+    ):
         return None
 
 
@@ -69,11 +121,14 @@ def _read_attrs(dataset_path):
         Parsed attributes (may be empty).
     """
     if _is_n5(dataset_path):
-        return _read_json_file(os.path.join(dataset_path, "attributes.json")) or {}
-    zarr_json = _read_json_file(os.path.join(dataset_path, "zarr.json"))
+        return _read_json_file(_path_join(dataset_path, "attributes.json")) or {}
+    zarr_json = _read_json_file(_path_join(dataset_path, "zarr.json"))
     if zarr_json is not None:
         return zarr_json.get("attributes", {})
-    return _read_json_file(os.path.join(dataset_path, ".zattrs")) or {}
+    zattrs = _read_json_file(_path_join(dataset_path, ".zattrs"))
+    if zattrs is not None:
+        return zattrs
+    return _read_json_file(_path_join(dataset_path, "attributes.json")) or {}
 
 
 def split_dataset_path(dataset_path):
@@ -90,9 +145,12 @@ def split_dataset_path(dataset_path):
         ``(container_path, dataset_name)`` e.g.
         ``("/data/seg.zarr", "volumes/labels/s0")``.
     """
-    splitter = (
-        ".zarr" if dataset_path.rfind(".zarr") > dataset_path.rfind(".n5") else ".n5"
-    )
+    zarr_pos = dataset_path.rfind(".zarr")
+    n5_pos = dataset_path.rfind(".n5")
+    if zarr_pos == -1 and n5_pos == -1:
+        return dataset_path, ""
+
+    splitter = ".zarr" if zarr_pos > n5_pos else ".n5"
     # Split on the LAST occurrence so nested containers like
     # ``outer.zarr/inner.zarr/s0`` resolve to ``inner.zarr`` + ``s0``.
     parts = dataset_path.rsplit(splitter, 1)
@@ -121,15 +179,29 @@ def open_dataset(filename, ds_name, mode="r"):
     CellMapArray
         Array wrapper with physical coordinate metadata.
     """
-    from mesh_n_bone.util.image_data_interface import open_ds_tensorstore
+    from mesh_n_bone.util.image_data_interface import (
+        _detect_zarr_driver,
+        open_ds_tensorstore,
+    )
 
     logger.debug("opening dataset %s in %s", ds_name, filename)
-    full_path = os.path.join(filename, ds_name) if ds_name else filename
+    full_path = _path_join(filename, ds_name) if ds_name else filename
 
     attrs = _read_attrs(full_path)
+    parent_attrs = None
+    metadata_dataset_name = None
+    selected_dataset_path = None
+    if not ds_name:
+        selected_dataset_path = _first_multiscales_dataset_path(attrs)
+        if selected_dataset_path:
+            parent_attrs = attrs
+            metadata_dataset_name = selected_dataset_path
+            full_path = _path_join(full_path, selected_dataset_path)
+            attrs = _read_attrs(full_path)
 
     try:
-        ts_ds = open_ds_tensorstore(full_path, mode=mode)
+        filetype = _detect_zarr_driver(full_path)
+        ts_ds = open_ds_tensorstore(full_path, mode=mode, filetype=filetype)
     except Exception as e:
         logger.error("failed to open %s/%s: %s", filename, ds_name, e)
         raise
@@ -141,16 +213,24 @@ def open_dataset(filename, ds_name, mode="r"):
     # N5 stores shape in XYZ order, but funlib expects ZYX.  Reverse so
     # ROI computation (shape * voxel_size) and chunk-aligned operations
     # use consistent axis order.
-    if _is_n5(full_path):
+    if filetype == "n5":
         shape = shape[::-1]
         chunks = chunks[::-1]
 
-    data = ArrayMetadata(shape, dtype, chunks, attrs)
-    parent_dir = os.path.dirname(full_path)
-    parent_attrs = _read_attrs(parent_dir) if parent_dir and parent_dir != full_path else None
-    dataset_name = os.path.basename(full_path) or None
+    if parent_attrs is None:
+        parent_dir = _path_dirname(full_path)
+        if parent_dir and parent_dir != full_path:
+            parent_attrs = _read_attrs(parent_dir)
+    if metadata_dataset_name is None:
+        metadata_dataset_name = _path_basename(full_path) or None
+
+    data = ArrayMetadata(
+        shape, dtype, chunks, attrs,
+        parent_attrs=parent_attrs,
+        dataset_name=metadata_dataset_name,
+    )
     voxel_size, offset = _read_voxel_size_offset(
-        data, parent_attrs=parent_attrs, dataset_name=dataset_name,
+        data, parent_attrs=parent_attrs, dataset_name=metadata_dataset_name,
     )
     return CellMapArray(data, voxel_size, offset, dataset_path=full_path)
 
@@ -252,8 +332,12 @@ def read_raw_voxel_size(ds):
     not round. Falls back to ``ds.voxel_size`` (already a Coordinate)
     when no metadata source declares a value.
     """
-    parent_attrs = _read_parent_attrs(ds)
-    dataset_name = os.path.basename(getattr(ds, "_dataset_path", "")) or None
+    parent_attrs = getattr(ds.data, "parent_attrs", None) or _read_parent_attrs(ds)
+    dataset_name = (
+        getattr(ds.data, "dataset_name", None)
+        or _path_basename(getattr(ds, "_dataset_path", ""))
+        or None
+    )
     voxel_size, _ = _resolve_voxel_size_offset(
         ds.data.attrs, parent_attrs, dataset_name,
     )
@@ -287,6 +371,20 @@ def _get_multiscales(attrs):
             sorted(ome.keys()),
         )
     return None
+
+
+def _first_multiscales_dataset_path(attrs):
+    """Return the first dataset path from OME-Zarr multiscales metadata."""
+    multiscales = _get_multiscales(attrs)
+    if not multiscales:
+        return None
+    ms = multiscales[0] if isinstance(multiscales, list) and multiscales else None
+    if not isinstance(ms, dict):
+        return None
+    datasets = ms.get("datasets") or []
+    if not datasets or not isinstance(datasets[0], dict):
+        return None
+    return datasets[0].get("path")
 
 
 def _read_transforms(transforms):
@@ -486,7 +584,11 @@ def _read_parent_attrs(ds):
     if dataset_path is None:
         return None
 
-    parent = os.path.dirname(dataset_path)
+    parent_attrs = getattr(ds.data, "parent_attrs", None)
+    if parent_attrs:
+        return parent_attrs
+
+    parent = _path_dirname(dataset_path)
     if parent and parent != dataset_path:
         attrs = _read_attrs(parent)
         if attrs:

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -1,7 +1,10 @@
 """Unit tests for OME-NGFF metadata helpers in mesh_n_bone.util.zarr_io."""
 
+import functools
+import http.server
 import logging
 import os
+import threading
 
 import numpy as np
 import pytest
@@ -16,6 +19,7 @@ from mesh_n_bone.util.zarr_io import (
     _read_voxel_size_offset,
     open_dataset,
     read_raw_voxel_size,
+    split_dataset_path,
 )
 
 
@@ -128,6 +132,26 @@ def _ome_zarr_factory(tmp_output_dir):
     return _make
 
 
+@pytest.fixture
+def _http_directory_server(tmp_output_dir):
+    """Serve *tmp_output_dir* over localhost HTTP for TensorStore tests."""
+
+    class QuietHandler(http.server.SimpleHTTPRequestHandler):
+        def log_message(self, format, *args):
+            pass
+
+    handler = functools.partial(QuietHandler, directory=tmp_output_dir)
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
 class TestOpenDatasetOmeFallback:
     """``open_dataset`` must pick up voxel_size/offset from either layout."""
 
@@ -146,6 +170,52 @@ class TestOpenDatasetOmeFallback:
         ds = open_dataset(*os.path.split(path))
         raw = read_raw_voxel_size(ds)
         assert raw == (8.0, 16.0, 32.0)
+
+    def test_open_http_zarr_without_extension(
+        self, tmp_output_dir, _http_directory_server,
+    ):
+        zarr_path = os.path.join(tmp_output_dir, "crop04_AIPv2")
+        root = zarr.open_group(zarr_path, mode="w")
+        root.create_array(
+            "seg/s0",
+            data=np.zeros((4, 4, 4), dtype=np.uint32),
+            chunks=(4, 4, 4),
+        )
+        root["seg"].attrs["multiscales"] = _multiscales_block(
+            [8, 16, 32], [10, 20, 30],
+        )
+
+        url = f"{_http_directory_server}/crop04_AIPv2/seg/s0"
+        ds = open_dataset(*split_dataset_path(url))
+
+        assert ds.shape == (4, 4, 4)
+        assert tuple(ds.voxel_size) == (8, 16, 32)
+        assert tuple(ds.roi.begin) == (10, 20, 30)
+
+    def test_open_http_ome_group_without_extension_selects_first_dataset(
+        self, tmp_output_dir, _http_directory_server,
+    ):
+        zarr_path = os.path.join(tmp_output_dir, "crop04_group")
+        root = zarr.open_group(zarr_path, mode="w")
+        root.create_array(
+            "seg/s0",
+            data=np.zeros((4, 4, 4), dtype=np.uint32),
+            chunks=(4, 4, 4),
+        )
+        ms = _multiscales_block([8.5, 16.5, 32.5], [10, 20, 30])
+        ms[0]["datasets"][0]["path"] = "seg/s0"
+        root.attrs["multiscales"] = ms
+
+        url = f"{_http_directory_server}/crop04_group"
+        ds = open_dataset(*split_dataset_path(url))
+
+        assert ds.shape == (4, 4, 4)
+        assert ds._dataset_path == f"{url}/seg/s0"
+        assert read_raw_voxel_size(ds) == (8.5, 16.5, 32.5)
+
+    def test_split_http_dataset_path_without_extension(self):
+        url = "https://fileglancer.int.janelia.org/files/id/crop04_AIPv2"
+        assert split_dataset_path(url) == (url, "")
 
 
 def _empty_meta(attrs=None):


### PR DESCRIPTION
@stuarteberg
## Summary
- Read zarr/n5 metadata and open TensorStore datasets from HTTP(S) URLs (read-only) in addition to local paths
- Accept inputs that don't end in `.zarr`/`.n5` — driver detection now inspects `zarr.json` / `.zarray` / `attributes.json` directly, and `split_dataset_path` tolerates extension-less paths
- Fall back to OME-Zarr multiscales group metadata when `input_path` points at a group rather than an array (opens the first listed dataset)
- Wire the new path helpers and driver-based n5 detection through meshify