### PR TITLE
Add sharded multi-resolution Draco mesh output

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,30 +1,696 @@
-Copyright 2021 HHMI.  All rights reserved.
+mesh-n-bone - Unified tool for mesh generation, multiresolution mesh
+creation, skeletonization, and analysis.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-    * Neither the name of HHMI nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Author: ackermand@janelia.hhmi.org (David Ackerman)
+Copyright (C) 2021-2026 Howard Hughes Medical Institute (HHMI)
+Author: David Ackerman <ackermand@janelia.hhmi.org>
 Written as part of the COSEM Project at Janelia Research Campus.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------------
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -339,3 +339,7 @@ tests/                      # Unit and integration tests
 ## Acknowledgments
 
 Thanks to [Luca Marconato](https://github.com/LucaMarconato) for the pixi configuration that informed macOS support and the neuroglancer serving approach ([#6](https://github.com/janelia-cellmap/mesh-n-bone/pull/6)).
+
+## License
+
+mesh-n-bone is distributed under the GNU General Public License v3.0 or later (GPL-3.0-or-later). See [LICENSE](LICENSE) for the full text.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See [examples/](examples/) for the full walkthrough.
 ## Features
 
 - **Meshify** — Generate meshes from `.zarr`, `.n5`, or [neuroglancer precomputed](https://github.com/google/neuroglancer/blob/master/src/neuroglancer/datasource/precomputed/volume.md) segmentation volumes (auto-detected; local, `http(s)://`, `gs://`, or `s3://`) via marching cubes, with blockwise processing, chunk assembly, simplification, and optional on-the-fly downsampling
-- **To-Neuroglancer** — Convert single-scale meshes into neuroglancer multiresolution Draco-compressed meshes with automatic LOD decimation
+- **To-Neuroglancer** — Convert single-scale meshes into neuroglancer multiresolution Draco-compressed meshes with automatic LOD decimation, optionally [sharded](https://github.com/google/neuroglancer/blob/master/src/datasource/precomputed/sharded.md) so thousands of meshes load with a handful of HTTP range requests instead of per-segment file fetches
 - **Skeletonize** — Extract skeletons from meshes using CGAL mean curvature flow, with pruning, simplification, and metrics
 - **Analyze** — Compute mesh metrics: volume, surface area, curvature, thickness, principal inertia, oriented bounds
 
@@ -109,6 +109,14 @@ num_lods: 3                      # Number of levels of detail (default: 3)
 multires_strategy: decimate      # LOD strategy: decimate or downsample (default: decimate)
 decimation_factor: 4             # Face reduction factor per LOD (default: 4)
 delete_decimated_meshes: true    # Remove intermediate LOD mesh files (default: true)
+
+# ── Sharded output (recommended for thousands of meshes) ──
+sharded: true                    # Pack all meshes into a few <n>.shard files
+                                 # instead of two files per segment (default: false)
+# shard_bits: 4                  # Optional overrides — defaults are auto-sized
+# minishard_bits: 6              # from the segment count via choose_shard_params.
+# preshift_bits: 0
+delete_unsharded_files: true     # Remove per-segment files after packing (default: true)
 
 # ── Coordinate system ──
 # Voxel size is read automatically from the dataset metadata (OME-NGFF or
@@ -190,6 +198,13 @@ optional_properties_settings:
   segment_properties_csv: /path/to/properties.csv  # CSV with per-segment metadata
   segment_properties_columns: [col1, col2]         # Which columns to include (default: all)
   segment_properties_id_column: "Object ID"        # CSV column with segment IDs
+
+sharding_settings:
+  sharded: true                                    # Pack output into <n>.shard files (default: false)
+  # shard_bits: 4                                  # Optional overrides — auto-sized by default
+  # minishard_bits: 6
+  # preshift_bits: 0
+  delete_unsharded_files: true                     # Remove per-segment files after packing (default: true)
 ```
 
 `box_size` can be a scalar (applied to all axes) or a 3-element list for per-axis control, which prevents degenerate triangles on elongated meshes.

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -29,9 +29,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "%pip install --quiet 'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git'"
-   ]
+   "source": "%pip install --quiet 'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git@mesh-sharding'"
   },
   {
    "cell_type": "markdown",

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -29,7 +29,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%pip install --quiet --force-reinstall 'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git@mesh-sharding'"
+   "source": "%pip install --quiet --upgrade 'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git@mesh-sharding'"
   },
   {
    "cell_type": "markdown",

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -29,7 +29,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%pip install --quiet --force-reinstall --no-deps 'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git@mesh-sharding'"
+   "source": "%pip install --quiet --force-reinstall 'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git@mesh-sharding'"
   },
   {
    "cell_type": "markdown",

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -29,7 +29,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%pip install --quiet 'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git@mesh-sharding'"
+   "source": "%pip install --quiet --force-reinstall --no-deps 'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git@mesh-sharding'"
   },
   {
    "cell_type": "markdown",

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -57,45 +57,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 3. Run meshify\n",
-    "\n",
-    "Marching cubes → simplification → multiresolution Draco output. Calls the `Meshify` class directly so we don't need a config file."
-   ]
+   "source": "## 3. Run meshify\n\nMarching cubes → simplification → multiresolution Draco output. Calls the `Meshify` class directly so we don't need a config file.\n\nWe also pass `sharded=True`, which packs the per-segment mesh files into a small number of `<n>.shard` files. With only 3 meshes the difference is invisible, but for thousands of segments it turns thousands of HTTP requests into a handful of range reads inside a few shard files. The unsharded layout writes two files per segment (`<id>` + `<id>.index`); the sharded layout writes one file per shard regardless of segment count."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from mesh_n_bone.meshify.meshify import Meshify\n",
-    "\n",
-    "output_dir = os.path.join(work_dir, 'output')\n",
-    "if os.path.exists(output_dir):\n",
-    "    shutil.rmtree(output_dir)\n",
-    "\n",
-    "meshify = Meshify(\n",
-    "    input_path=array_path,\n",
-    "    output_directory=output_dir,\n",
-    "    num_workers=1,\n",
-    "    do_simplification=True,\n",
-    "    target_reduction=0.5,\n",
-    "    n_smoothing_iter=2,\n",
-    "    check_mesh_validity=False,\n",
-    "    do_multires=True,\n",
-    "    num_lods=3,\n",
-    "    multires_strategy='decimate',\n",
-    "    decimation_factor=2,\n",
-    "    # Lower than the production default (25,000) so these small toy meshes\n",
-    "    # split into enough chunks for multires loading to be apparent in the viewer.\n",
-    "    target_faces_per_lod0_chunk=2000,\n",
-    "    delete_decimated_meshes=True,\n",
-    "    do_analysis=False,\n",
-    ")\n",
-    "meshify.get_meshes()\n",
-    "print('Meshes written to', output_dir)"
-   ]
+   "source": "from mesh_n_bone.meshify.meshify import Meshify\n\noutput_dir = os.path.join(work_dir, 'output')\nif os.path.exists(output_dir):\n    shutil.rmtree(output_dir)\n\nmeshify = Meshify(\n    input_path=array_path,\n    output_directory=output_dir,\n    num_workers=1,\n    do_simplification=True,\n    target_reduction=0.5,\n    n_smoothing_iter=2,\n    check_mesh_validity=False,\n    do_multires=True,\n    num_lods=3,\n    multires_strategy='decimate',\n    decimation_factor=2,\n    # Lower than the production default (25,000) so these small toy meshes\n    # split into enough chunks for multires loading to be apparent in the viewer.\n    target_faces_per_lod0_chunk=2000,\n    delete_decimated_meshes=True,\n    do_analysis=False,\n    # Pack the multires output into <n>.shard files; see the section above.\n    sharded=True,\n)\nmeshify.get_meshes()\nprint('Meshes written to', output_dir)"
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "mesh-n-bone"
-version = "0.2.0"
+version = "0.3.0"
 description = "Unified tool for mesh generation, multiresolution mesh creation, skeletonization, and analysis."
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [
   { name = "David Ackerman", email = "ackermand@janelia.hhmi.org" },
 ]
-license = "BSD-3-Clause"
+license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]
 keywords = ["mesh", "neuroglancer", "skeletonization", "multiresolution", "segmentation", "neuroscience"]
 classifiers = [

--- a/src/mesh_n_bone/config.py
+++ b/src/mesh_n_bone/config.py
@@ -77,7 +77,19 @@ def read_multires_config(config_path):
         if "segment_properties_id_column" not in optional_properties_settings:
             optional_properties_settings["segment_properties_id_column"] = "Object ID"
 
-        return required_settings, optional_decimation_settings, optional_properties_settings
+        sharding_settings = config.get("sharding_settings", {}) or {}
+        sharding_settings.setdefault("sharded", False)
+        sharding_settings.setdefault("preshift_bits", None)
+        sharding_settings.setdefault("minishard_bits", None)
+        sharding_settings.setdefault("shard_bits", None)
+        sharding_settings.setdefault("delete_unsharded_files", True)
+
+        return (
+            required_settings,
+            optional_decimation_settings,
+            optional_properties_settings,
+            sharding_settings,
+        )
 
 
 def read_generic_config(config_path):

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -419,6 +419,11 @@ class Meshify:
         voxel_size_nm: list = None,
         retry_on_oom: bool = True,
         memory_retry_max: int = 3,
+        sharded: bool = False,
+        shard_bits: int | None = None,
+        minishard_bits: int | None = None,
+        preshift_bits: int | None = None,
+        delete_unsharded_files: bool = True,
     ):
         filename, dataset_name = split_dataset_path(input_path)
         self.segmentation_array = open_dataset(filename, dataset_name)
@@ -568,6 +573,11 @@ class Meshify:
         self.segment_properties_csv = segment_properties_csv
         self.segment_properties_columns = segment_properties_columns
         self.segment_properties_id_column = segment_properties_id_column
+        self.sharded = sharded
+        self.shard_bits = shard_bits
+        self.minishard_bits = minishard_bits
+        self.preshift_bits = preshift_bits
+        self.delete_unsharded_files = delete_unsharded_files
         self.coordinate_units = coordinate_units
         self.retry_on_oom = retry_on_oom
         self.memory_retry_max = memory_retry_max
@@ -1352,15 +1362,61 @@ class Meshify:
             max_retries=self.memory_retry_max, retry_on_oom=self.retry_on_oom,
         )
 
-        with Timing_Messager("Writing info and segment properties files", logger):
-            multires_path = f"{self.output_directory}/multires"
+        multires_path = f"{self.output_directory}/multires"
+        with Timing_Messager("Writing segment properties file", logger):
+            # Always write segment_properties before sharding (it scans
+            # `.index` files, which are removed once shards are packed).
             neuroglancer.write_segment_properties_file(
                 multires_path,
                 csv_path=self.segment_properties_csv,
                 csv_columns=self.segment_properties_columns,
                 csv_id_column=self.segment_properties_id_column,
             )
-            neuroglancer.write_info_file(multires_path)
+
+        if self.sharded:
+            from mesh_n_bone.util import sharded_mesh_util
+
+            params = sharded_mesh_util.choose_shard_params(len(mesh_ids))
+            for key, override in (
+                ("preshift_bits", self.preshift_bits),
+                ("minishard_bits", self.minishard_bits),
+                ("shard_bits", self.shard_bits),
+            ):
+                if override is not None:
+                    params[key] = int(override)
+            spec = sharded_mesh_util.make_sharding_spec(**params)
+
+            def _pack(workers, config):
+                with dask_util.start_dask(
+                    workers, "shard packing", logger, config=config,
+                ):
+                    with Timing_Messager(
+                        f"Packing meshes into sharded format ({params})", logger
+                    ):
+                        sharded_mesh_util.pack_meshes_to_shards(
+                            multires_path, mesh_ids, spec, workers,
+                        )
+
+            dask_util.run_with_oom_retry(
+                _pack, effective_workers, "shard packing", logger,
+                max_retries=self.memory_retry_max, retry_on_oom=self.retry_on_oom,
+            )
+
+            with Timing_Messager("Writing sharded info file", logger):
+                sharded_mesh_util.write_sharded_info_file(
+                    multires_path, spec, vertex_quantization_bits=16,
+                )
+
+            if self.delete_unsharded_files:
+                with Timing_Messager(
+                    "Deleting unsharded per-segment files", logger
+                ):
+                    sharded_mesh_util.delete_unsharded_segment_files(
+                        multires_path, mesh_ids,
+                    )
+        else:
+            with Timing_Messager("Writing info file", logger):
+                neuroglancer.write_info_file(multires_path)
 
         if self.delete_decimated_meshes:
             with Timing_Messager("Cleaning up intermediate mesh files", logger):

--- a/src/mesh_n_bone/multires/multires.py
+++ b/src/mesh_n_bone/multires/multires.py
@@ -405,9 +405,12 @@ def run_multires(config_path, num_workers, roi=None):
         region will be processed.
     """
     submission_directory = os.getcwd()
-    required_settings, optional_decimation_settings, optional_properties_settings = (
-        read_multires_config(config_path)
-    )
+    (
+        required_settings,
+        optional_decimation_settings,
+        optional_properties_settings,
+        sharding_settings,
+    ) = read_multires_config(config_path)
 
     input_path = required_settings["input_path"]
     output_path = required_settings["output_path"]
@@ -522,17 +525,61 @@ def run_multires(config_path, num_workers, roi=None):
                 max_retries=memory_retry_max, retry_on_oom=retry_on_oom,
             )
 
-            with Timing_Messager("Writing info and segment properties files", logger):
-                multires_output_path = f"{output_path}/multires"
+            multires_output_path = f"{output_path}/multires"
+            with Timing_Messager("Writing segment properties file", logger):
+                # Write segment_properties before sharding so it can still scan
+                # the per-segment `.index` files; they get removed once shards
+                # are packed.
                 neuroglancer.write_segment_properties_file(
                     multires_output_path,
                     csv_path=segment_properties_csv,
                     csv_columns=segment_properties_columns,
                     csv_id_column=segment_properties_id_column,
                 )
-                neuroglancer.write_info_file(
-                    multires_output_path, vertex_quantization_bits=16,
+
+            if sharding_settings["sharded"]:
+                from mesh_n_bone.util import sharded_mesh_util
+
+                params = sharded_mesh_util.choose_shard_params(len(mesh_ids))
+                for key in ("preshift_bits", "minishard_bits", "shard_bits"):
+                    override = sharding_settings.get(key)
+                    if override is not None:
+                        params[key] = int(override)
+                spec = sharded_mesh_util.make_sharding_spec(**params)
+
+                def _pack(workers, config):
+                    with dask_util.start_dask(
+                        workers, "shard packing", logger, config=config,
+                    ):
+                        with Timing_Messager(
+                            f"Packing meshes into sharded format ({params})", logger
+                        ):
+                            sharded_mesh_util.pack_meshes_to_shards(
+                                multires_output_path, mesh_ids, spec, workers,
+                            )
+
+                dask_util.run_with_oom_retry(
+                    _pack, effective_workers, "shard packing", logger,
+                    max_retries=memory_retry_max, retry_on_oom=retry_on_oom,
                 )
+
+                with Timing_Messager("Writing sharded info file", logger):
+                    sharded_mesh_util.write_sharded_info_file(
+                        multires_output_path, spec, vertex_quantization_bits=16,
+                    )
+
+                if sharding_settings["delete_unsharded_files"]:
+                    with Timing_Messager(
+                        "Deleting unsharded per-segment files", logger
+                    ):
+                        sharded_mesh_util.delete_unsharded_segment_files(
+                            multires_output_path, mesh_ids,
+                        )
+            else:
+                with Timing_Messager("Writing info file", logger):
+                    neuroglancer.write_info_file(
+                        multires_output_path, vertex_quantization_bits=16,
+                    )
 
             if not skip_decimation and delete_decimated_meshes_flag:
                 with dask_util.start_dask(

--- a/src/mesh_n_bone/util/dask_util.py
+++ b/src/mesh_n_bone/util/dask_util.py
@@ -168,8 +168,8 @@ def setup_execution_directory(config_path, logger):
     """Create a timestamped copy of a configuration directory for execution.
 
     The new directory name is ``<config_path>-<YYYYmmdd.HHMMSS>``. The
-    ``run-config.yaml`` inside is made read-only to prevent accidental
-    modification during a run.
+    ``run-config.yaml`` and ``dask-config.yaml`` inside are made
+    read-only to prevent accidental modification during a run.
 
     Parameters
     ----------
@@ -188,7 +188,10 @@ def setup_execution_directory(config_path, logger):
     execution_dir = f"{config_path}-{timestamp}"
     execution_dir = os.path.abspath(execution_dir)
     shutil.copytree(config_path, execution_dir, symlinks=True)
-    os.chmod(f"{execution_dir}/run-config.yaml", 0o444)
+    for name in ("run-config.yaml", "dask-config.yaml"):
+        path = f"{execution_dir}/{name}"
+        if os.path.exists(path):
+            os.chmod(path, 0o444)
     print_with_datetime(f"Setup working directory as {execution_dir}.", logger)
 
     return execution_dir

--- a/src/mesh_n_bone/util/sharded_mesh_util.py
+++ b/src/mesh_n_bone/util/sharded_mesh_util.py
@@ -211,9 +211,17 @@ def pack_meshes_to_shards(
         return []
 
     bag = db.from_sequence(shard_items, npartitions=min(len(shard_items), max(1, num_workers)))
-    futures = bag.map(
+    bag = bag.map(
         lambda item: pack_one_shard(item[0], item[1], multires_dir, output_dir, spec_dict)
-    ).persist()
+    )
+
+    if num_workers == 1:
+        # Synchronous scheduler — no distributed Client exists (see
+        # `dask_util.start_dask`), so use `.compute()` rather than the
+        # `persist()`+`wait()` Client-based path.
+        return list(bag.compute())
+
+    futures = bag.persist()
     [completed, _] = wait(futures)
     failed = [f for f in completed if f.exception() is not None]
     paths = [f.result() for f in completed if f.exception() is None]

--- a/src/mesh_n_bone/util/sharded_mesh_util.py
+++ b/src/mesh_n_bone/util/sharded_mesh_util.py
@@ -1,0 +1,236 @@
+"""Pack unsharded Neuroglancer multi-resolution Draco meshes into the
+sharded precomputed format.
+
+The unsharded writer produces two files per segment in `multires/`:
+  - `<id>`       : concatenated Draco fragments (fragment data)
+  - `<id>.index` : binary manifest
+
+The sharded format stores all segments in a small number of `<shard>.shard`
+files. For each chunk the layout is `<fragment_data> || <manifest>`, and the
+minishard index points at the manifest only (size = len(manifest)). The
+reader uses the manifest to locate the fragment block, which lives in the
+shard file immediately before the manifest.
+
+We use cloud-volume's `ShardingSpecification` for the hash / index math and
+`synthesize_shard_file` to assemble each shard. Parallelism is driven by
+dask (one task per shard).
+"""
+
+import json
+import math
+import os
+from collections import defaultdict
+from typing import Dict, Iterable, List, Tuple
+
+import dask.bag as db
+import numpy as np
+from cloudvolume.datasource.precomputed import mmh3 as _cv_mmh3
+from cloudvolume.datasource.precomputed.sharding import (
+    ShardingSpecification,
+    synthesize_shard_file,
+)
+from dask.distributed import wait
+
+
+def _murmur3_x86_128_unsigned(value: int) -> np.uint64:
+    """Compute murmurhash3_x86_128 low 64 bits as an unsigned numpy uint64.
+
+    Cloud-volume's stock hashfn does `uint64(hash64(...)[0])`, but its bundled
+    pure-Python hash64 returns a signed int (negative for high-bit-set values),
+    and `np.uint64(negative_int)` raises OverflowError under newer numpy. Mask
+    to 64 bits before the conversion.
+    """
+
+    signed = _cv_mmh3.hash64(np.uint64(int(value)).tobytes(), x64arch=False)[0]
+    return np.uint64(signed & 0xFFFFFFFFFFFFFFFF)
+
+
+def choose_shard_params(num_segments: int) -> Dict[str, int]:
+    """Pick reasonable preshift/minishard/shard bits for `num_segments`.
+
+    Aims for roughly ~32 segments per minishard and a handful of shards.
+    Returns a dict with preshift_bits, minishard_bits, shard_bits.
+    """
+
+    n = max(1, int(num_segments))
+    # Total bins ~= n / 32, split between shards and minishards.
+    total_bits = max(0, int(math.ceil(math.log2(max(1, n / 32.0)))))
+    # Cap each below 16 so a single shard does not balloon.
+    shard_bits = min(total_bits // 2, 6)
+    minishard_bits = max(0, min(total_bits - shard_bits, 10))
+    return {
+        "preshift_bits": 0,
+        "minishard_bits": int(minishard_bits),
+        "shard_bits": int(shard_bits),
+    }
+
+
+def make_sharding_spec(
+    preshift_bits: int = 0,
+    minishard_bits: int = 6,
+    shard_bits: int = 2,
+    hash_fn: str = "murmurhash3_x86_128",
+) -> ShardingSpecification:
+    """Build a ShardingSpecification with raw encodings (draco is pre-compressed)."""
+
+    spec = ShardingSpecification(
+        type="neuroglancer_uint64_sharded_v1",
+        preshift_bits=int(preshift_bits),
+        minishard_bits=int(minishard_bits),
+        shard_bits=int(shard_bits),
+        hash=hash_fn,
+        minishard_index_encoding="raw",
+        data_encoding="raw",
+    )
+    if hash_fn == "murmurhash3_x86_128":
+        spec.hashfn = _murmur3_x86_128_unsigned
+    return spec
+
+
+def group_segment_ids_by_shard(
+    spec: ShardingSpecification, segment_ids: Iterable[int]
+) -> Dict[str, List[int]]:
+    """Return {shard_filename_base: [segment_id, ...]} for the given spec."""
+
+    grouping: Dict[str, List[int]] = defaultdict(list)
+    for seg_id in segment_ids:
+        loc = spec.compute_shard_location(int(seg_id))
+        grouping[str(loc.shard_number)].append(int(seg_id))
+    return grouping
+
+
+def _read_segment_chunk(
+    multires_dir: str, seg_id: int
+) -> Tuple[bytes, int] | None:
+    """Read `<id>` + `<id>.index`, return (chunk_binary, manifest_size).
+
+    Returns None if the segment has no fragments (no `<id>.index` written).
+    """
+
+    index_path = os.path.join(multires_dir, f"{seg_id}.index")
+    frag_path = os.path.join(multires_dir, str(seg_id))
+    if not os.path.exists(index_path):
+        return None
+    with open(index_path, "rb") as f:
+        manifest_bytes = f.read()
+    if os.path.exists(frag_path):
+        with open(frag_path, "rb") as f:
+            fragment_bytes = f.read()
+    else:
+        fragment_bytes = b""
+    return fragment_bytes + manifest_bytes, len(manifest_bytes)
+
+
+def pack_one_shard(
+    shard_name: str,
+    segment_ids: List[int],
+    multires_dir: str,
+    output_dir: str,
+    spec_dict: Dict,
+) -> str:
+    """Assemble a single `<shard_name>.shard` file from its segments.
+
+    Designed to run on a dask worker. Re-creates the ShardingSpecification
+    from a JSON-able dict so it ships cleanly across processes.
+    """
+
+    spec = ShardingSpecification.from_dict(spec_dict)
+    if spec.hash == "murmurhash3_x86_128":
+        spec.hashfn = _murmur3_x86_128_unsigned
+
+    data: Dict[int, bytes] = {}
+    data_offset: Dict[int, int] = {}
+    for seg_id in segment_ids:
+        chunk = _read_segment_chunk(multires_dir, seg_id)
+        if chunk is None:
+            continue
+        binary, manifest_size = chunk
+        data[seg_id] = binary
+        data_offset[seg_id] = manifest_size
+
+    if not data:
+        # Empty shard: still write a header-only file so reads don't 404.
+        # synthesize_shard_file handles the empty case via its fixed index.
+        pass
+
+    shard_bytes = synthesize_shard_file(
+        spec, data, data_offset=data_offset, progress=False, presorted=False
+    )
+    out_path = os.path.join(output_dir, f"{shard_name}.shard")
+    with open(out_path, "wb") as f:
+        f.write(shard_bytes)
+    return out_path
+
+
+def write_sharded_info_file(
+    path: str, spec: ShardingSpecification, vertex_quantization_bits: int = 16
+) -> None:
+    """Write the top-level `info` for sharded multi-resolution Draco meshes.
+
+    Default of 16 matches the encoder default in
+    `mesh_n_bone.multires.multires.generate_neuroglancer_multires_mesh` and
+    the unsharded `write_info_file`. The value MUST equal whatever the
+    encoder used, or Neuroglancer will decode vertices at the wrong scale
+    and the mesh geometry will appear stretched or shrunk by a power of 2.
+    """
+
+    # spec.to_dict() may contain numpy uint64 — coerce to plain ints for JSON.
+    sharding = {
+        k: (int(v) if isinstance(v, (np.integer,)) else v)
+        for k, v in spec.to_dict().items()
+    }
+    info = {
+        "@type": "neuroglancer_multilod_draco",
+        "vertex_quantization_bits": int(vertex_quantization_bits),
+        "transform": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0],
+        "lod_scale_multiplier": 1,
+        "segment_properties": "segment_properties",
+        "sharding": sharding,
+    }
+    with open(os.path.join(path, "info"), "w") as f:
+        json.dump(info, f)
+
+
+def pack_meshes_to_shards(
+    multires_dir: str,
+    segment_ids: Iterable[int],
+    spec: ShardingSpecification,
+    num_workers: int,
+    output_dir: str | None = None,
+) -> List[str]:
+    """Group segments by shard, dispatch one dask task per shard, return written paths."""
+
+    output_dir = output_dir or multires_dir
+    os.makedirs(output_dir, exist_ok=True)
+
+    grouping = group_segment_ids_by_shard(spec, segment_ids)
+    spec_dict = spec.to_dict()
+
+    shard_items = list(grouping.items())  # [(shard_name, [ids]), ...]
+    if not shard_items:
+        return []
+
+    bag = db.from_sequence(shard_items, npartitions=min(len(shard_items), max(1, num_workers)))
+    futures = bag.map(
+        lambda item: pack_one_shard(item[0], item[1], multires_dir, output_dir, spec_dict)
+    ).persist()
+    [completed, _] = wait(futures)
+    failed = [f for f in completed if f.exception() is not None]
+    paths = [f.result() for f in completed if f.exception() is None]
+    for c in completed:
+        c.cancel()
+    if failed:
+        raise RuntimeError(f"Failed to pack {len(failed)} shards: {failed}")
+    return paths
+
+
+def delete_unsharded_segment_files(multires_dir: str, segment_ids: Iterable[int]) -> None:
+    """Remove `<id>` and `<id>.index` after they've been packed into shards."""
+
+    for seg_id in segment_ids:
+        for suffix in ("", ".index"):
+            p = os.path.join(multires_dir, f"{seg_id}{suffix}")
+            try:
+                os.remove(p)
+            except FileNotFoundError:
+                pass

--- a/tests/test_integration_multires.py
+++ b/tests/test_integration_multires.py
@@ -367,6 +367,122 @@ class TestFullMultiresPipeline:
         assert "1" in sp["inline"]["ids"]
 
 
+class TestShardedPipeline:
+    """End-to-end check: full unsharded multires output → pack into shards →
+    read back through the Neuroglancer spec and DracoPy-decode every
+    non-empty fragment. If any byte offset, hash, or layout assumption is
+    wrong, decoding will fail."""
+
+    def _build_multires(self, multires_mesh_dir, lods=(0, 1)):
+        from mesh_n_bone.util.neuroglancer import write_segment_properties_file
+        generate_neuroglancer_multires_mesh(
+            id=1,
+            num_subtask_workers=1,
+            output_path=multires_mesh_dir,
+            lods=list(lods),
+            original_ext=".ply",
+        )
+        multires_dir = os.path.join(multires_mesh_dir, "multires")
+        # Write segment_properties BEFORE sharding (it scans .index files).
+        write_segment_properties_file(multires_dir)
+        return multires_dir
+
+    def test_sharded_round_trip(self, multires_mesh_dir):
+        """Pack and verify that minishard index → manifest → fragments line up."""
+        import DracoPy
+        from mesh_n_bone.util import sharded_mesh_util
+
+        multires_dir = self._build_multires(multires_mesh_dir)
+        ids = [1]
+
+        # Snapshot pre-pack files for ground truth.
+        with open(os.path.join(multires_dir, "1.index"), "rb") as f:
+            expected_manifest = f.read()
+        with open(os.path.join(multires_dir, "1"), "rb") as f:
+            expected_fragments = f.read()
+
+        spec = sharded_mesh_util.make_sharding_spec(0, 1, 0)
+        grouping = sharded_mesh_util.group_segment_ids_by_shard(spec, ids)
+        for sn, sids in grouping.items():
+            sharded_mesh_util.pack_one_shard(
+                sn, sids, multires_dir, multires_dir, spec.to_dict(),
+            )
+        sharded_mesh_util.write_sharded_info_file(multires_dir, spec)
+        sharded_mesh_util.delete_unsharded_segment_files(multires_dir, ids)
+
+        # info JSON should announce the sharding block.
+        with open(os.path.join(multires_dir, "info")) as f:
+            info = json.load(f)
+        assert info["sharding"]["@type"] == "neuroglancer_uint64_sharded_v1"
+
+        # Unsharded files should be gone.
+        assert not os.path.exists(os.path.join(multires_dir, "1"))
+        assert not os.path.exists(os.path.join(multires_dir, "1.index"))
+
+        # Read the shard exactly the way Neuroglancer would.
+        spec.hashfn = sharded_mesh_util._murmur3_x86_128_unsigned
+        loc = spec.compute_shard_location(1)
+        with open(
+            os.path.join(multires_dir, f"{loc.shard_number}.shard"), "rb"
+        ) as f:
+            shard = f.read()
+        fixed_index_len = int(spec.index_length())
+        fixed = np.frombuffer(
+            shard[:fixed_index_len], dtype=np.uint64
+        ).reshape(-1, 2)
+        msi_s = int(fixed[int(loc.minishard_number), 0])
+        msi_e = int(fixed[int(loc.minishard_number), 1])
+        msi = (
+            np.frombuffer(
+                shard[fixed_index_len + msi_s : fixed_index_len + msi_e],
+                dtype=np.uint64,
+            )
+            .reshape(3, -1).T.copy()
+        )
+        for i in range(1, msi.shape[0]):
+            msi[i, 0] += msi[i - 1, 0]
+            msi[i, 1] += msi[i - 1, 1] + msi[i - 1, 2]
+        msi[:, 1] += fixed_index_len
+        row = next(r for r in msi if int(r[0]) == 1)
+        offset, size = int(row[1]), int(row[2])
+
+        # Manifest matches the original `.index` exactly.
+        assert shard[offset : offset + size] == expected_manifest
+        # Fragments live immediately before the manifest.
+        assert shard[offset - len(expected_fragments) : offset] == expected_fragments
+
+        # Decode every non-empty Draco fragment for at least the first LOD.
+        # If the byte slice for a LOD is even one byte off, DracoPy will raise.
+        g = expected_manifest
+        chunk_shape = np.frombuffer(g[:12], dtype="<f4"); g = g[12:]
+        grid_origin = np.frombuffer(g[:12], dtype="<f4"); g = g[12:]
+        (num_lods,) = struct.unpack("<I", g[:4]); g = g[4:]
+        g = g[4 * num_lods :]
+        g = g[12 * num_lods :]
+        num_frags = np.frombuffer(g[: 4 * num_lods], dtype="<u4"); g = g[4 * num_lods:]
+        sizes_per_lod = []
+        for n in num_frags:
+            n = int(n)
+            g = g[4 * 3 * n :]
+            sizes_per_lod.append(np.frombuffer(g[: 4 * n], dtype="<u4"))
+            g = g[4 * n :]
+
+        total_decoded = 0
+        cursor = offset - sum(int(s.sum()) for s in sizes_per_lod)
+        for lod_sizes in sizes_per_lod:
+            sub = 0
+            block = shard[cursor : cursor + int(lod_sizes.sum())]
+            for sz in lod_sizes:
+                sz = int(sz)
+                if sz == 0:
+                    continue
+                DracoPy.decode(block[sub : sub + sz])  # raises on bad bytes
+                total_decoded += 1
+                sub += sz
+            cursor += int(lod_sizes.sum())
+        assert total_decoded > 0, "expected at least one decoded fragment"
+
+
 class TestLodTruncation:
     """Test that LOD truncation correctly includes all valid LODs.
 

--- a/tests/test_multires.py
+++ b/tests/test_multires.py
@@ -66,7 +66,7 @@ class TestMultiresConfig:
         with open(os.path.join(config_dir, "run-config.yaml"), "w") as f:
             yaml.dump(config, f)
 
-        required, optional, _ = read_multires_config(config_dir)
+        required, optional, _, _ = read_multires_config(config_dir)
         assert required["num_lods"] == 3
         np.testing.assert_array_equal(optional["box_size"], [100.0, 100.0, 100.0])
 
@@ -86,7 +86,7 @@ class TestMultiresConfig:
         with open(os.path.join(config_dir, "run-config.yaml"), "w") as f:
             yaml.dump(config, f)
 
-        _, optional, _ = read_multires_config(config_dir)
+        _, optional, _, _ = read_multires_config(config_dir)
         np.testing.assert_array_equal(optional["box_size"], [20.0, 40.0, 60.0])
 
     def test_box_size_scalar_broadcasts_to_3d(self, tmp_output_dir):
@@ -105,5 +105,5 @@ class TestMultiresConfig:
         with open(os.path.join(config_dir, "run-config.yaml"), "w") as f:
             yaml.dump(config, f)
 
-        _, optional, _ = read_multires_config(config_dir)
+        _, optional, _, _ = read_multires_config(config_dir)
         np.testing.assert_array_equal(optional["box_size"], [50.0, 50.0, 50.0])

--- a/tests/test_roi.py
+++ b/tests/test_roi.py
@@ -279,7 +279,7 @@ class TestMultiresRoiFilter:
         with open(os.path.join(config_dir, "run-config.yaml"), "w") as f:
             yaml.dump(config, f)
 
-        _, optional, _ = read_multires_config(config_dir)
+        _, optional, _, _ = read_multires_config(config_dir)
         assert optional["roi"] is not None
         assert optional["roi"]["begin"] == [10, 20, 30]
         assert optional["roi"]["end"] == [100, 200, 300]
@@ -300,7 +300,7 @@ class TestMultiresRoiFilter:
         with open(os.path.join(config_dir, "run-config.yaml"), "w") as f:
             yaml.dump(config, f)
 
-        _, optional, _ = read_multires_config(config_dir)
+        _, optional, _, _ = read_multires_config(config_dir)
         assert optional["roi"] is None
 
 

--- a/tests/test_sharded_mesh_util.py
+++ b/tests/test_sharded_mesh_util.py
@@ -1,0 +1,294 @@
+"""Unit tests for `mesh_n_bone.util.sharded_mesh_util`.
+
+These exercise the sharded multi-resolution Draco mesh writer without
+running the full Meshify pipeline: we synthesize fake manifest + fragment
+files, pack them, then read them back per the Neuroglancer spec and
+verify every byte lands where it should.
+"""
+
+import json
+import os
+import struct
+
+import numpy as np
+import pytest
+
+from mesh_n_bone.util import sharded_mesh_util
+
+
+# ---------- helpers ----------
+
+def _fake_manifest_bytes(num_lods: int = 1) -> bytes:
+    """Minimal valid multi-resolution mesh manifest."""
+
+    chunk_shape = np.array([16.0, 16.0, 16.0], dtype="<f4").tobytes()
+    grid_origin = np.zeros(3, dtype="<f4").tobytes()
+    header = struct.pack("<I", num_lods)
+    lod_scales = np.array([2 ** i for i in range(num_lods)], dtype="<f4").tobytes()
+    vertex_offsets = np.zeros((num_lods, 3), dtype="<f4").tobytes(order="C")
+    num_frags = np.array([1] * num_lods, dtype="<u4").tobytes()
+    positions = np.zeros((3, 1), dtype="<u4").tobytes(order="C") * num_lods
+    sizes = (np.array([8], dtype="<u4").tobytes()) * num_lods
+    return (
+        chunk_shape + grid_origin + header + lod_scales + vertex_offsets
+        + num_frags + positions + sizes
+    )
+
+
+def _fake_fragment_bytes(seg_id: int, num_lods: int = 1) -> bytes:
+    """`num_lods` × 8 bytes of "fragment data" tagged with the seg id."""
+
+    return (seg_id.to_bytes(8, "little")) * num_lods
+
+
+def _parse_manifest(buf: bytes):
+    g = buf
+    chunk_shape = np.frombuffer(g[:12], dtype="<f4"); g = g[12:]
+    grid_origin = np.frombuffer(g[:12], dtype="<f4"); g = g[12:]
+    (num_lods,) = struct.unpack("<I", g[:4]); g = g[4:]
+    g = g[4 * num_lods :]                       # lod_scales
+    g = g[12 * num_lods :]                      # vertex_offsets
+    num_frags = np.frombuffer(g[: 4 * num_lods], dtype="<u4"); g = g[4 * num_lods:]
+    sizes_per_lod = []
+    for n in num_frags:
+        n = int(n)
+        g = g[4 * 3 * n :]                      # positions
+        sizes_per_lod.append(np.frombuffer(g[: 4 * n], dtype="<u4"))
+        g = g[4 * n :]
+    return chunk_shape, grid_origin, sizes_per_lod
+
+
+def _decode_minishard_index(msi_bytes: bytes, fixed_index_len: int):
+    msi = (
+        np.frombuffer(msi_bytes, dtype=np.uint64)
+        .reshape(3, -1).T.copy()
+    )
+    for i in range(1, msi.shape[0]):
+        msi[i, 0] += msi[i - 1, 0]
+        msi[i, 1] += msi[i - 1, 1] + msi[i - 1, 2]
+    msi[:, 1] += fixed_index_len
+    return msi
+
+
+def _stage_fake_meshes(multires_dir: str, seg_ids, num_lods: int = 1):
+    os.makedirs(multires_dir, exist_ok=True)
+    expected = {}
+    for sid in seg_ids:
+        manifest = _fake_manifest_bytes(num_lods)
+        fragment = _fake_fragment_bytes(sid, num_lods)
+        with open(os.path.join(multires_dir, f"{sid}.index"), "wb") as f:
+            f.write(manifest)
+        with open(os.path.join(multires_dir, str(sid)), "wb") as f:
+            f.write(fragment)
+        expected[sid] = (fragment, manifest)
+    return expected
+
+
+# ---------- tests ----------
+
+class TestChooseShardParams:
+    @pytest.mark.parametrize(
+        "n",
+        [1, 10, 100, 1_000, 9_000, 100_000, 1_000_000, 10_000_000],
+    )
+    def test_params_are_sane(self, n):
+        p = sharded_mesh_util.choose_shard_params(n)
+        assert p["preshift_bits"] == 0
+        assert 0 <= p["shard_bits"] <= 6
+        assert 0 <= p["minishard_bits"] <= 10
+        assert p["shard_bits"] + p["minishard_bits"] <= 16  # total cap
+
+
+class TestShardingSpec:
+    def test_make_spec_round_trips_through_dict(self):
+        spec = sharded_mesh_util.make_sharding_spec(0, 6, 2)
+        d = spec.to_dict()
+        assert d["@type"] == "neuroglancer_uint64_sharded_v1"
+        assert int(d["preshift_bits"]) == 0
+        assert int(d["minishard_bits"]) == 6
+        assert int(d["shard_bits"]) == 2
+        assert d["minishard_index_encoding"] == "raw"
+        assert d["data_encoding"] == "raw"
+
+    def test_hashfn_is_unsigned(self):
+        """Cloud-volume's stock hashfn raises OverflowError on negative
+        signed values under newer numpy — make sure ours doesn't."""
+        spec = sharded_mesh_util.make_sharding_spec(0, 4, 2)
+        # Compute hash for a sample of IDs; any one of these tripped the bug.
+        for sid in (1, 12345, 999_999, 2**62):
+            loc = spec.compute_shard_location(sid)
+            assert 0 <= int(loc.shard_number, 16) < 2**2
+            assert 0 <= int(loc.minishard_number) < 2**4
+
+    def test_distribution_roughly_uniform(self):
+        spec = sharded_mesh_util.make_sharding_spec(0, 6, 2)
+        counts = {}
+        for sid in range(1, 10_001):
+            loc = spec.compute_shard_location(sid)
+            counts[loc.shard_number] = counts.get(loc.shard_number, 0) + 1
+        # 4 shards expected; each should get ~2500 ± reasonable slack.
+        assert set(counts) == {format(i, "x") for i in range(4)}
+        assert all(2000 < c < 3000 for c in counts.values())
+
+
+class TestGroupByShard:
+    def test_grouping_partitions_all_ids(self):
+        spec = sharded_mesh_util.make_sharding_spec(0, 2, 1)
+        ids = [1, 2, 3, 100, 999, 12345]
+        grouping = sharded_mesh_util.group_segment_ids_by_shard(spec, ids)
+        assert sorted(sum(grouping.values(), [])) == sorted(ids)
+        # Two shard files possible (shard_bits=1).
+        assert set(grouping) <= {"0", "1"}
+
+
+class TestPackOneShard:
+    def test_writes_shard_with_correct_layout(self, tmp_output_dir):
+        """Pack two segments, then read back and verify:
+          - shard file exists
+          - minishard index points at the manifest bytes we wrote
+          - the fragment data sits immediately before the manifest
+        """
+        multires = os.path.join(tmp_output_dir, "multires")
+        expected = _stage_fake_meshes(multires, [1, 2])
+        spec = sharded_mesh_util.make_sharding_spec(0, 2, 0)
+        grouping = sharded_mesh_util.group_segment_ids_by_shard(spec, [1, 2])
+        shard_name, shard_ids = next(iter(grouping.items()))
+
+        out_path = sharded_mesh_util.pack_one_shard(
+            shard_name, shard_ids, multires, multires, spec.to_dict(),
+        )
+        assert os.path.exists(out_path)
+        assert os.path.getsize(out_path) > 0
+
+        with open(out_path, "rb") as f:
+            shard = f.read()
+
+        fixed_index_len = int(spec.index_length())
+        fixed = np.frombuffer(
+            shard[:fixed_index_len], dtype=np.uint64
+        ).reshape(-1, 2)
+        for sid in shard_ids:
+            loc = spec.compute_shard_location(sid)
+            msi_s = int(fixed[int(loc.minishard_number), 0])
+            msi_e = int(fixed[int(loc.minishard_number), 1])
+            msi_bytes = shard[
+                fixed_index_len + msi_s : fixed_index_len + msi_e
+            ]
+            msi = _decode_minishard_index(msi_bytes, fixed_index_len)
+            row = next(r for r in msi if int(r[0]) == sid)
+            offset, size = int(row[1]), int(row[2])
+            fragment, manifest = expected[sid]
+            # Minishard index points at the manifest.
+            assert shard[offset : offset + size] == manifest
+            # Fragment data sits immediately before.
+            assert shard[offset - len(fragment) : offset] == fragment
+
+    def test_handles_missing_index_file_gracefully(self, tmp_output_dir):
+        """If a segment has no .index file, it should be silently skipped."""
+        multires = os.path.join(tmp_output_dir, "multires")
+        os.makedirs(multires)
+        # Stage only seg 1; reference both in the pack call.
+        _stage_fake_meshes(multires, [1])
+        spec = sharded_mesh_util.make_sharding_spec(0, 2, 0)
+        path = sharded_mesh_util.pack_one_shard(
+            "0", [1, 2], multires, multires, spec.to_dict(),
+        )
+        assert os.path.exists(path)
+
+
+class TestInfoFile:
+    def test_info_serializes_cleanly(self, tmp_output_dir):
+        spec = sharded_mesh_util.make_sharding_spec(0, 6, 2)
+        sharded_mesh_util.write_sharded_info_file(tmp_output_dir, spec)
+        with open(os.path.join(tmp_output_dir, "info")) as f:
+            info = json.load(f)
+        assert info["@type"] == "neuroglancer_multilod_draco"
+        assert info["sharding"]["@type"] == "neuroglancer_uint64_sharded_v1"
+        # Plain ints (not numpy types) so the file is portable.
+        assert isinstance(info["sharding"]["minishard_bits"], int)
+        assert isinstance(info["sharding"]["shard_bits"], int)
+
+    def test_default_quantization_matches_encoder(self, tmp_output_dir):
+        """Default `vertex_quantization_bits` must match the encoder default
+        (16) and the unsharded `write_info_file` default (16). A mismatch
+        decodes vertex coordinates at the wrong scale and meshes render
+        stretched or shrunk by a power of 2.
+        """
+        from mesh_n_bone.util import neuroglancer as ng_util
+        spec = sharded_mesh_util.make_sharding_spec(0, 6, 2)
+        sharded_mesh_util.write_sharded_info_file(tmp_output_dir, spec)
+        with open(os.path.join(tmp_output_dir, "info")) as f:
+            sharded_info = json.load(f)
+
+        unsharded_dir = os.path.join(tmp_output_dir, "unsharded")
+        os.makedirs(unsharded_dir)
+        ng_util.write_info_file(unsharded_dir)
+        with open(os.path.join(unsharded_dir, "info")) as f:
+            unsharded_info = json.load(f)
+
+        assert (
+            sharded_info["vertex_quantization_bits"]
+            == unsharded_info["vertex_quantization_bits"]
+        ), "sharded and unsharded info files must declare the same quantization"
+
+
+class TestPackMeshesToShards:
+    def test_dask_path_matches_direct(self, tmp_output_dir):
+        """The dask orchestrator should write byte-identical shards to the
+        direct per-shard call."""
+        from dask.distributed import Client, LocalCluster
+
+        seg_ids = [1, 2, 3, 4, 5, 100, 999, 12345]
+        a = os.path.join(tmp_output_dir, "direct")
+        b = os.path.join(tmp_output_dir, "dask")
+        _stage_fake_meshes(a, seg_ids)
+        _stage_fake_meshes(b, seg_ids)
+
+        spec = sharded_mesh_util.make_sharding_spec(0, 2, 1)
+
+        # Direct
+        for shard_name, ids in sharded_mesh_util.group_segment_ids_by_shard(
+            spec, seg_ids
+        ).items():
+            sharded_mesh_util.pack_one_shard(
+                shard_name, ids, a, a, spec.to_dict(),
+            )
+
+        # Dask
+        cluster = LocalCluster(
+            n_workers=2, processes=True, threads_per_worker=1,
+            dashboard_address=None,
+        )
+        client = Client(cluster)
+        try:
+            sharded_mesh_util.pack_meshes_to_shards(b, seg_ids, spec, num_workers=2)
+        finally:
+            client.close()
+            cluster.close()
+
+        a_shards = sorted(n for n in os.listdir(a) if n.endswith(".shard"))
+        b_shards = sorted(n for n in os.listdir(b) if n.endswith(".shard"))
+        assert a_shards == b_shards
+        for name in a_shards:
+            with open(os.path.join(a, name), "rb") as fa, open(
+                os.path.join(b, name), "rb"
+            ) as fb:
+                assert fa.read() == fb.read(), f"shard {name} differs"
+
+
+class TestDeleteUnsharded:
+    def test_removes_per_segment_files(self, tmp_output_dir):
+        multires = os.path.join(tmp_output_dir, "multires")
+        _stage_fake_meshes(multires, [1, 2, 3])
+        # Sanity: files exist before.
+        for sid in (1, 2, 3):
+            assert os.path.exists(os.path.join(multires, str(sid)))
+            assert os.path.exists(os.path.join(multires, f"{sid}.index"))
+        sharded_mesh_util.delete_unsharded_segment_files(multires, [1, 2, 3])
+        for sid in (1, 2, 3):
+            assert not os.path.exists(os.path.join(multires, str(sid)))
+            assert not os.path.exists(os.path.join(multires, f"{sid}.index"))
+
+    def test_missing_files_do_not_raise(self, tmp_output_dir):
+        # Should be a no-op when nothing is present.
+        sharded_mesh_util.delete_unsharded_segment_files(tmp_output_dir, [42])

--- a/tests/test_sharded_mesh_util.py
+++ b/tests/test_sharded_mesh_util.py
@@ -233,6 +233,24 @@ class TestInfoFile:
 
 
 class TestPackMeshesToShards:
+    def test_synchronous_single_worker(self, tmp_output_dir):
+        """`num_workers=1` runs without a distributed Client (synchronous
+        scheduler). pack_meshes_to_shards must take a separate compute()
+        path because persist()/wait() require a Client.
+        """
+        import dask
+
+        multires = os.path.join(tmp_output_dir, "multires")
+        _stage_fake_meshes(multires, [1, 2, 3, 4, 5])
+        spec = sharded_mesh_util.make_sharding_spec(0, 2, 1)
+        with dask.config.set(scheduler="synchronous"):
+            paths = sharded_mesh_util.pack_meshes_to_shards(
+                multires, [1, 2, 3, 4, 5], spec, num_workers=1,
+            )
+        assert paths and all(p.endswith(".shard") for p in paths)
+        for p in paths:
+            assert os.path.exists(p) and os.path.getsize(p) > 0
+
     def test_dask_path_matches_direct(self, tmp_output_dir):
         """The dask orchestrator should write byte-identical shards to the
         direct per-shard call."""


### PR DESCRIPTION
## Summary

- Pack per-segment `<id>` + `<id>.index` files into Neuroglancer's [sharded precomputed format](https://github.com/google/neuroglancer/blob/master/src/datasource/precomputed/sharded.md) so thousands of meshes load with a handful of HTTP range requests instead of per-segment fetches. Sharding is opt-in via `sharded: true` (`Meshify`) or a top-level `sharding_settings` block (`run_multires`); shard/minishard counts are auto-sized from segment count with explicit overrides for `shard_bits`, `minishard_bits`, and `preshift_bits`. Packer runs in dask, one task per shard.
- Coverage: 19 unit tests in `tests/test_sharded_mesh_util.py` (hash distribution, shard layout, dask-vs-direct byte-identity, missing-file tolerance, and a regression test pinning `vertex_quantization_bits` to the encoder's value), plus an integration test in `test_integration_multires.py::TestShardedPipeline` that builds a real LOD0/LOD1 output, packs it, and DracoPy-decodes every non-empty fragment via the Neuroglancer-spec read path.
- Also: lock `dask-config.yaml` read-only in the execution directory (matches existing `run-config.yaml` behavior); surface the sharded option in README and the example notebook.