### PR TITLE
Add target_ids: meshify only specific segment IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,16 @@ roi:                             # Restrict processing to this subregion
   end: [500, 600, 700]           # End coordinates in dataset world units (ZYX)
                                  # Boundary edges are preserved during simplification.
                                  # Can also be passed via CLI: --roi z0,y0,x0,z1,y1,x1
+
+# ── Specific segment ids only (optional) ──
+# When set, only the listed ids are meshified — every other voxel is
+# zeroed before marching cubes via fastremap.mask_except, so zmesh does
+# no work on unwanted objects. Blocks containing none of the targets
+# are skipped entirely.
+target_ids: [12345, 67890]                # YAML list of ids, OR
+# target_ids: /path/to/ids.csv            # CSV file (first col, or "id"/"Object ID" col)
+# target_ids: 12345                       # Single id
+                                          # CLI: --ids 12345,67890  OR  --ids /path.csv
 ```
 
 `input_path` accepts any of `.zarr`, `.n5`, or neuroglancer precomputed sources, from any of these locations:

--- a/src/mesh_n_bone/cli.py
+++ b/src/mesh_n_bone/cli.py
@@ -61,6 +61,21 @@ def _get_run_properties(args):
     return execution_directory, logpath, run_config
 
 
+def _parse_ids_arg(value):
+    """Parse a ``--ids`` argument.
+
+    Accepts either a comma-separated list of integer ids
+    (``--ids 12345,67890``) or a path to a CSV file whose first column
+    (or column named ``id``/``ID``/``Object ID``/``object_id``) holds
+    the ids. Returns the value to pass to ``Meshify(target_ids=...)``
+    (a list[int] or a string path — both are handled by Meshify's
+    normalize logic).
+    """
+    if "," in value or value.strip().isdigit():
+        return [int(p) for p in value.split(",") if p.strip()]
+    return value  # treat as a file path; Meshify will read it
+
+
 def _parse_roi_arg(roi_str):
     """Parse a ``--roi`` argument into a dict with ``begin`` and ``end`` keys.
 
@@ -111,6 +126,8 @@ def cmd_meshify(args):
     execution_directory, logpath, run_config = _get_run_properties(args)
     if args.roi:
         run_config["roi"] = _parse_roi_arg(args.roi)
+    if args.ids:
+        run_config["target_ids"] = _parse_ids_arg(args.ids)
     with tee_streams(logpath):
         os.chdir(execution_directory)
         try:
@@ -261,6 +278,16 @@ def main():
         type=str,
         default=None,
         help="ROI to process (ZYX): begin_z,begin_y,begin_x,end_z,end_y,end_x",
+    )
+    p_meshify.add_argument(
+        "--ids",
+        type=str,
+        default=None,
+        help=(
+            "Only meshify the given segment IDs. Accepts either a "
+            "comma-separated list (e.g. --ids 12345,67890) or a path to "
+            "a CSV file with one ID per row."
+        ),
     )
     p_meshify.set_defaults(func=cmd_meshify)
 

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -12,6 +12,7 @@ import shutil
 import trimesh
 import json
 import pymeshlab
+import fastremap
 from mesh_n_bone.util import dask_util
 from mesh_n_bone.util.logging import Timing_Messager
 from mesh_n_bone.util.zarr_io import (
@@ -154,6 +155,32 @@ def staged_reductions(target_reduction_total, frac1, frac2):
 _thread_local_ts = {}
 
 
+def _normalize_target_ids(value):
+    """Coerce a target_ids spec to a frozenset[int] or None.
+
+    Accepts:
+      - None: process every label found in the volume (default)
+      - int: a single segment id
+      - list/tuple/set of ints: multiple ids
+      - str: path to a CSV file containing one id per row, either
+        headerless (uses first column) or with a column named
+        ``id``, ``ID``, ``Object ID``, or ``object_id``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, np.integer)):
+        return frozenset([int(value)])
+    if isinstance(value, str):
+        import pandas as pd
+        df = pd.read_csv(value)
+        col = next(
+            (c for c in ("id", "ID", "Object ID", "object_id") if c in df.columns),
+            df.columns[0],
+        )
+        return frozenset(int(v) for v in df[col].dropna().tolist())
+    return frozenset(int(i) for i in value)
+
+
 def _get_chunked_mesh_worker(block, tmpdirname, config):
     """Run marching cubes on a single block and write per-segment PLYs.
 
@@ -208,6 +235,28 @@ def _get_chunked_mesh_worker(block, tmpdirname, config):
             ds_func = methods[dm]
             segmentation_block, _ = ds_func(segmentation_block, downsample_factor)
 
+    # If the user supplied target_ids, zero out every voxel whose label
+    # isn't in the keep list BEFORE running marching cubes. That way zmesh
+    # only does work for the requested objects; blocks containing none of
+    # them exit immediately. We optionally renumber the surviving labels
+    # to small consecutive ids so zmesh's internal arrays use a smaller
+    # dtype, then map the resulting mesh ids back to the originals.
+    target_ids_tuple = config.get("target_ids")
+    inv_remap = None
+    if target_ids_tuple:
+        keep = list(target_ids_tuple)
+        segmentation_block = fastremap.mask_except(
+            segmentation_block, keep, in_place=False
+        )
+        if not segmentation_block.any():
+            return  # no target ids in this block; skip MC entirely
+        if segmentation_block.dtype.itemsize > 2 and len(keep) < (1 << 16):
+            remap = {old: new for new, old in enumerate(sorted(keep), start=1)}
+            inv_remap = {new: old for old, new in remap.items()}
+            segmentation_block = fastremap.remap(
+                segmentation_block, remap, preserve_missing_labels=True,
+            ).astype(np.uint16)
+
     block_offset = np.array(block.roi.get_begin())
     # Correct for the half-kernel shift introduced by downsampling:
     # a downsampled voxel at index 0 represents original voxels [0, ds),
@@ -215,6 +264,7 @@ def _get_chunked_mesh_worker(block, tmpdirname, config):
     ds_shift = (downsample_factor - 1) / 2 * np.array(voxel_size) if downsample_factor else np.zeros(3)
     mesher.mesh(segmentation_block, close=False)
     for id in mesher.ids():
+        original_id = inv_remap[int(id)] if inv_remap is not None else int(id)
         mesh = mesher.get_mesh(id)
 
         if config["use_fixed_edge_simplification"] and config["do_simplification"]:
@@ -262,15 +312,15 @@ def _get_chunked_mesh_worker(block, tmpdirname, config):
                 normals=None,
             )
 
-            os.makedirs(f"{tmpdirname}/{id}", exist_ok=True)
-            with open(f"{tmpdirname}/{id}/block_{block.index}.ply", "wb") as fp:
+            os.makedirs(f"{tmpdirname}/{original_id}", exist_ok=True)
+            with open(f"{tmpdirname}/{original_id}/block_{block.index}.ply", "wb") as fp:
                 fp.write(mesh_simplified.to_ply())
         else:
             if len(mesh.vertices) == 0:
                 continue
             mesh.vertices += block_offset[::-1] + ds_shift[::-1]
-            os.makedirs(f"{tmpdirname}/{id}", exist_ok=True)
-            with open(f"{tmpdirname}/{id}/block_{block.index}.ply", "wb") as fp:
+            os.makedirs(f"{tmpdirname}/{original_id}", exist_ok=True)
+            with open(f"{tmpdirname}/{original_id}/block_{block.index}.ply", "wb") as fp:
                 fp.write(mesh.to_ply())
 
 
@@ -321,6 +371,16 @@ class Meshify:
         a clean surface. Empirically ~2× lower RMS deviation from truth
         at the same final face count vs the reverse order. Set ``False``
         to restore the legacy decimate-then-smooth ordering.
+    target_ids : int, list of int, str, or None
+        Only meshify the listed segment ids. ``None`` (default) processes
+        every label found in the volume. Accepts a single int, a list of
+        ints, or a path to a CSV file (uses the first column or a column
+        named ``id``/``Object ID``/...). When set, the chunk worker zeros
+        out every voxel whose label isn't in the keep list BEFORE running
+        marching cubes (via ``fastremap.mask_except``), and blocks that
+        contain none of the targets are skipped entirely. Labels are
+        optionally renumbered to a smaller dtype for zmesh efficiency
+        and mapped back to the originals when writing PLYs.
     default_aggressiveness : float
         Aggressiveness parameter for quadric-error simplification.
     check_mesh_validity : bool
@@ -437,6 +497,7 @@ class Meshify:
         preshift_bits: int | None = None,
         delete_unsharded_files: bool = True,
         smooth_before_simplify: bool = True,
+        target_ids: int | list[int] | None = None,
     ):
         filename, dataset_name = split_dataset_path(input_path)
         self.segmentation_array = open_dataset(filename, dataset_name)
@@ -592,6 +653,7 @@ class Meshify:
         self.preshift_bits = preshift_bits
         self.delete_unsharded_files = delete_unsharded_files
         self.smooth_before_simplify = smooth_before_simplify
+        self.target_ids = _normalize_target_ids(target_ids)
         self.coordinate_units = coordinate_units
         self.retry_on_oom = retry_on_oom
         self.memory_retry_max = memory_retry_max
@@ -689,6 +751,11 @@ class Meshify:
             "stage_2_reduction_fraction": self.stage_2_reduction_fraction,
             "read_write_block_shape_pixels": self.read_write_block_shape_pixels.tolist(),
             "default_aggressiveness": self.default_aggressiveness,
+            # Sorted tuple for pickling; worker materializes a numpy array
+            # for np.isin. None means "process every label found in block."
+            "target_ids": (
+                tuple(sorted(self.target_ids)) if self.target_ids is not None else None
+            ),
         }
 
     @staticmethod

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,31 @@ class TestCLI:
         )
         assert result.returncode == 1
 
+    def test_parse_ids_arg_comma_list(self):
+        from mesh_n_bone.cli import _parse_ids_arg
+        assert _parse_ids_arg("123,456,789") == [123, 456, 789]
+
+    def test_parse_ids_arg_single_int(self):
+        from mesh_n_bone.cli import _parse_ids_arg
+        assert _parse_ids_arg("42") == [42]
+
+    def test_parse_ids_arg_csv_path(self):
+        from mesh_n_bone.cli import _parse_ids_arg
+        # No commas, not all-digits → treated as a path string,
+        # passed through to Meshify which knows how to read it.
+        path = "/some/path/ids.csv"
+        assert _parse_ids_arg(path) == path
+
+    def test_meshify_help_shows_ids(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "mesh_n_bone.cli", "meshify", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "--ids" in result.stdout
+        assert "segment IDs" in result.stdout or "segment ids" in result.stdout.lower()
+
     def test_skeletonize_single_help(self):
         result = subprocess.run(
             [sys.executable, "-m", "mesh_n_bone.cli", "skeletonize-single", "--help"],

--- a/tests/test_integration_meshify.py
+++ b/tests/test_integration_meshify.py
@@ -62,6 +62,71 @@ class TestMeshifyFromZarr:
             assert len(mesh.faces) > 0
             assert mesh.volume > 0
 
+    def test_target_ids_filters_output(self, tmp_output_dir):
+        """`target_ids=[1]` should produce ONLY mesh 1, even though
+        the volume also has object 2."""
+        vol = np.zeros((32, 32, 32), dtype=np.uint64)
+        vol[2:14, 2:14, 2:14] = 1
+        vol[18:30, 18:30, 18:30] = 2
+
+        input_path = _create_zarr_volume(tmp_output_dir, vol)
+        output_dir = os.path.join(tmp_output_dir, "output")
+
+        m = Meshify(
+            input_path=input_path,
+            output_directory=output_dir,
+            num_workers=1,
+            do_analysis=False,
+            check_mesh_validity=False,
+            do_simplification=False,
+            n_smoothing_iter=0,
+            remove_smallest_components=False,
+            target_ids=[1],
+        )
+        m.get_meshes()
+
+        mesh_dir = os.path.join(output_dir, "meshes")
+        meshes = sorted(os.listdir(mesh_dir))
+        assert meshes == ["1.ply"], (
+            f"target_ids=[1] should produce only 1.ply, got {meshes}"
+        )
+        mesh = trimesh.load(os.path.join(mesh_dir, "1.ply"))
+        # Volume should match object 1 (12^3 voxels × 8^3 nm³/voxel)
+        np.testing.assert_allclose(mesh.volume, 12**3 * 8**3, rtol=0.1)
+
+    def test_target_ids_csv_input(self, tmp_output_dir):
+        """`target_ids` set to a CSV file path should load the ids from
+        the file and meshify exactly those."""
+        vol = np.zeros((32, 32, 32), dtype=np.uint64)
+        vol[2:10, 2:10, 2:10] = 1
+        vol[12:20, 12:20, 12:20] = 2
+        vol[22:30, 22:30, 22:30] = 3
+
+        input_path = _create_zarr_volume(tmp_output_dir, vol)
+        output_dir = os.path.join(tmp_output_dir, "output")
+
+        ids_csv = os.path.join(tmp_output_dir, "ids.csv")
+        with open(ids_csv, "w") as f:
+            f.write("id\n1\n3\n")
+
+        m = Meshify(
+            input_path=input_path,
+            output_directory=output_dir,
+            num_workers=1,
+            do_analysis=False,
+            check_mesh_validity=False,
+            do_simplification=False,
+            n_smoothing_iter=0,
+            remove_smallest_components=False,
+            target_ids=ids_csv,
+        )
+        m.get_meshes()
+
+        meshes = sorted(os.listdir(os.path.join(output_dir, "meshes")))
+        assert meshes == ["1.ply", "3.ply"], (
+            f"CSV [1,3] should produce 1.ply + 3.ply only, got {meshes}"
+        )
+
     def test_cross_chunk_object_is_watertight(self, tmp_output_dir):
         """An object spanning multiple chunks should assemble into a watertight mesh."""
         vol = np.zeros((32, 32, 32), dtype=np.uint64)

--- a/tests/test_meshify.py
+++ b/tests/test_meshify.py
@@ -1,8 +1,88 @@
 """Tests for meshify module components."""
 
+import os
 import numpy as np
 import pytest
 import trimesh
+
+
+class TestNormalizeTargetIds:
+    """target_ids accepts None, int, list, or CSV path."""
+
+    def test_none_returns_none(self):
+        from mesh_n_bone.meshify.meshify import _normalize_target_ids
+        assert _normalize_target_ids(None) is None
+
+    def test_int_wrapped(self):
+        from mesh_n_bone.meshify.meshify import _normalize_target_ids
+        assert _normalize_target_ids(12345) == frozenset([12345])
+
+    def test_list_converted(self):
+        from mesh_n_bone.meshify.meshify import _normalize_target_ids
+        assert _normalize_target_ids([1, 2, 3]) == frozenset([1, 2, 3])
+
+    def test_csv_with_id_column(self, tmp_output_dir):
+        from mesh_n_bone.meshify.meshify import _normalize_target_ids
+        path = os.path.join(tmp_output_dir, "ids.csv")
+        with open(path, "w") as f:
+            f.write("id\n10\n20\n30\n")
+        assert _normalize_target_ids(path) == frozenset([10, 20, 30])
+
+    def test_csv_with_object_id_column(self, tmp_output_dir):
+        from mesh_n_bone.meshify.meshify import _normalize_target_ids
+        path = os.path.join(tmp_output_dir, "ids.csv")
+        with open(path, "w") as f:
+            f.write("Object ID,other_col\n10,foo\n20,bar\n")
+        assert _normalize_target_ids(path) == frozenset([10, 20])
+
+    def test_csv_headerless_first_column(self, tmp_output_dir):
+        from mesh_n_bone.meshify.meshify import _normalize_target_ids
+        path = os.path.join(tmp_output_dir, "ids.csv")
+        # Pandas treats the first row as a header by default; with no
+        # known id-column name, our normalize falls back to first column.
+        with open(path, "w") as f:
+            f.write("seg\n100\n200\n")
+        assert _normalize_target_ids(path) == frozenset([100, 200])
+
+
+class TestTargetIdsWorker:
+    """Block-worker behavior when target_ids is set."""
+
+    def _config(self, **overrides):
+        """Minimal worker config (only the keys this test path reads)."""
+        base = {
+            "downsample_factor": None,
+            "downsample_method": "nearest",
+            "use_fixed_edge_simplification": False,
+            "do_simplification": False,
+            "target_reduction": 0.99,
+            "stage_1_reduction_fraction": 0.5,
+            "read_write_block_shape_pixels": [16, 16, 16],
+            "default_aggressiveness": 0.3,
+            "target_ids": None,
+        }
+        base.update(overrides)
+        return base
+
+    def test_mask_except_keeps_only_targets(self):
+        """fastremap.mask_except behaves the way the worker expects it to."""
+        import fastremap
+        vol = np.array([0, 1, 2, 3, 1, 5, 1], dtype=np.uint64)
+        out = fastremap.mask_except(vol, [1, 3], in_place=False)
+        np.testing.assert_array_equal(out, [0, 1, 0, 3, 1, 0, 1])
+
+    def test_renumber_round_trips(self):
+        """The remap dict the worker builds round-trips correctly."""
+        import fastremap
+        keep = [42, 7, 1000]
+        remap = {old: new for new, old in enumerate(sorted(keep), start=1)}
+        inv_remap = {new: old for old, new in remap.items()}
+        vol = np.array([0, 42, 7, 1000, 42, 0], dtype=np.uint64)
+        small = fastremap.remap(vol, remap, preserve_missing_labels=True).astype(np.uint16)
+        np.testing.assert_array_equal(small, [0, 2, 1, 3, 2, 0])
+        # And inverse
+        for new, old in inv_remap.items():
+            assert remap[old] == new
 
 
 class TestStagedReductions:


### PR DESCRIPTION
## Summary

- New `target_ids` kwarg on `Meshify` (and `--ids` CLI flag) that filters the meshify pipeline to a specific set of segment IDs. Accepts an int, a list of ints, or a CSV file path (one ID per row, supports `id` / `Object ID` / first-column conventions).
- The chunk worker uses `fastremap.mask_except` to zero out non-target voxels BEFORE running marching cubes — so zmesh only meshes the requested objects, and blocks containing none of them return immediately (no MC work). Labels are renumbered to uint16 (when dtype > 2 bytes and `<2^16` targets) for zmesh efficiency, then mapped back to original IDs when writing PLYs.
- Stacked on PR #32 (smooth-before-decimate). Base set to that branch; will merge into master once #32 lands.