### PR TITLE
Cap per-worker TBB and tensorstore thread pools

### DIFF
--- a/src/mesh_n_bone/util/dask_util.py
+++ b/src/mesh_n_bone/util/dask_util.py
@@ -96,6 +96,14 @@ def start_dask(num_workers, msg, logger, config=None):
         with open("dask-config.yaml") as f:
             config = yaml.load(f, Loader=SafeLoader)
 
+    # Pin every common thread-pool source to a single thread per worker.
+    # OMP/MKL/OPENBLAS/NUMEXPR cover numpy/scipy/BLAS; TBB covers pymeshlab
+    # and meshlab's internal C++ filters (Taubin smoothing, vertex merge,
+    # etc.) which ignore the OMP family. Without TBB_NUM_THREADS each
+    # process can spawn ~N_CPU TBB workers during stage-2 simplification,
+    # which together with the dozens of dask workers stacked on a single
+    # LSF host trivially overwhelms the node (observed load avg >1000 on
+    # a 96-core box with 60 workers prior to this change).
     job_script_prologue = [
         "export NUMEXPR_MAX_THREADS=1",
         "export NUMEXPR_NUM_THREADS=1",
@@ -104,6 +112,9 @@ def start_dask(num_workers, msg, logger, config=None):
         "export OPENBLAS_NUM_THREADS=1",
         "export OPENMP_NUM_THREADS=1",
         "export OMP_NUM_THREADS=1",
+        "export TBB_NUM_THREADS=1",
+        # Some Intel runtimes have a separate KMP threadcount knob.
+        "export KMP_NUM_THREADS=1",
     ]
 
     cluster_type = next(iter(config["jobqueue"]))

--- a/src/mesh_n_bone/util/image_data_interface.py
+++ b/src/mesh_n_bone/util/image_data_interface.py
@@ -25,6 +25,31 @@ from mesh_n_bone.util.precomputed_io import (
 logger = logging.getLogger(__name__)
 
 
+def _capped_tensorstore_context_spec():
+    """Tensorstore Context spec that limits internal thread pools.
+
+    Tensorstore defaults every concurrency resource (HTTP fetch pools,
+    data-copy / decompression pool, file I/O pool) to a high number,
+    typically N_CPU. In a dask-worker process — where dask itself
+    already runs us in a 1-thread-per-worker model — those default
+    pools combine with the dozens of worker processes stacked on a
+    single LSF host to produce thousands of runnable threads and
+    nodes-over-100%-load complaints from cluster admins. Cap each
+    pool to a small fixed limit so per-process thread count is bounded.
+    """
+    return {
+        # In-memory copying + decompression (e.g. gzip/blosc for zarr/n5).
+        "data_copy_concurrency": {"limit": 1},
+        # Local file I/O (irrelevant for remote sources but caps anyway).
+        "file_io_concurrency": {"limit": 1},
+        # GCS / S3 / generic HTTP fetch pools — allow 2 so a fetch can
+        # be in flight while the previous chunk is being decompressed.
+        "gcs_request_concurrency": {"limit": 2},
+        "s3_request_concurrency": {"limit": 2},
+        "http_request_concurrency": {"limit": 2},
+    }
+
+
 def _detect_zarr_driver(dataset_path):
     """Detect the tensorstore driver for *dataset_path* by content probing.
 
@@ -113,6 +138,7 @@ def open_ds_tensorstore(dataset_path, mode="r", filetype=None):
     spec = {
         "driver": filetype,
         "kvstore": kvstore,
+        "context": _capped_tensorstore_context_spec(),
     }
     if mode == "r":
         dataset_future = ts.open(spec, read=True, write=False)

--- a/src/mesh_n_bone/util/precomputed_io.py
+++ b/src/mesh_n_bone/util/precomputed_io.py
@@ -133,6 +133,9 @@ def open_precomputed_tensorstore(path, scale_index=None):
     converts it to ZYX.
     """
     import tensorstore as ts
+    from mesh_n_bone.util.image_data_interface import (
+        _capped_tensorstore_context_spec,
+    )
 
     kvstore, base_path, info, default_scale = parse_precomputed_path(path)
     if scale_index is None:
@@ -145,6 +148,7 @@ def open_precomputed_tensorstore(path, scale_index=None):
         "driver": "neuroglancer_precomputed",
         "kvstore": kvstore_with_path,
         "scale_index": int(scale_index),
+        "context": _capped_tensorstore_context_spec(),
     }
     ds = ts.open(spec, read=True, write=False).result()
 


### PR DESCRIPTION
## Summary

- Cluster admin reported nodes overloaded (load avg >1000 on a 96-core box) by mesh-n-bone runs that stacked multiple LSF worker jobs on one host. Each dask worker process was spawning ~N_CPU internal threads from two sources the existing prologue didn't cap.
- Add `TBB_NUM_THREADS=1` (and `KMP_NUM_THREADS=1` for Intel KMP) to `job_script_prologue` in `start_dask`. pymeshlab/meshlab's C++ filters use Intel TBB, which ignores `OMP_NUM_THREADS` et al; without this each pymeshlab call expanded to ~one-thread-per-core.
- Add `_capped_tensorstore_context_spec()` helper and embed it in both `ts.open()` call sites (general zarr/n5 in `open_ds_tensorstore`; precomputed in `open_precomputed_tensorstore`). Caps `data_copy_concurrency`, `file_io_concurrency`, `gcs_request_concurrency`, `s3_request_concurrency`, and `http_request_concurrency` to 1-2 threads instead of tensorstore's default N_CPU.