### PR TITLE
Improve efficiency: thread caps, lazy block enumeration, memory-driven block sizing, timeout tuning, sharded-by-default

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ delete_decimated_meshes: true    # Remove intermediate LOD mesh files (default: 
 
 # ── Sharded output (recommended for thousands of meshes) ──
 sharded: true                    # Pack all meshes into a few <n>.shard files
-                                 # instead of two files per segment (default: false)
+                                 # instead of two files per segment (default: true)
 # shard_bits: 4                  # Optional overrides — defaults are auto-sized
 # minishard_bits: 6              # from the segment count via choose_shard_params.
 # preshift_bits: 0
@@ -224,7 +224,7 @@ optional_properties_settings:
   segment_properties_id_column: "Object ID"        # CSV column with segment IDs
 
 sharding_settings:
-  sharded: true                                    # Pack output into <n>.shard files (default: false)
+  sharded: true                                    # Pack output into <n>.shard files (default: true)
   # shard_bits: 4                                  # Optional overrides — auto-sized by default
   # minishard_bits: 6
   # preshift_bits: 0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Produces meshes in the [neuroglancer precomputed format](https://github.com/goog
 
 ## Try it in Colab
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/janelia-cellmap/mesh-n-bone/blob/master/examples/example.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/janelia-cellmap/mesh-n-bone/blob/improve-efficiency/examples/example.ipynb)
 
 The [example notebook](examples/example.ipynb) runs the full pipeline end-to-end (build a zarr volume, generate meshes, view in neuroglancer) without any local setup.
 

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -55,14 +55,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 3. Run meshify\n\nMarching cubes → simplification → multiresolution Draco output. Calls the `Meshify` class directly so we don't need a config file.\n\nWe also pass `sharded=True`, which packs the per-segment mesh files into a small number of `<n>.shard` files. With only 3 meshes the difference is invisible, but for thousands of segments it turns thousands of HTTP requests into a handful of range reads inside a few shard files. The unsharded layout writes two files per segment (`<id>` + `<id>.index`); the sharded layout writes one file per shard regardless of segment count."
+   "source": "## 3. Run meshify\n\nMarching cubes → simplification → multiresolution Draco output. Calls the `Meshify` class directly so we don't need a config file.\n\nBy default, `Meshify` packs the per-segment mesh files into a small number of `<n>.shard` files (`sharded=True`). With only 3 meshes the difference is invisible, but for thousands of segments it turns thousands of HTTP requests into a handful of range reads inside a few shard files. The unsharded layout writes two files per segment (`<id>` + `<id>.index`); the sharded layout writes one file per shard regardless of segment count. Pass `sharded=False` to opt out."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "from mesh_n_bone.meshify.meshify import Meshify\n\noutput_dir = os.path.join(work_dir, 'output')\nif os.path.exists(output_dir):\n    shutil.rmtree(output_dir)\n\nmeshify = Meshify(\n    input_path=array_path,\n    output_directory=output_dir,\n    num_workers=1,\n    do_simplification=True,\n    target_reduction=0.5,\n    n_smoothing_iter=2,\n    check_mesh_validity=False,\n    do_multires=True,\n    num_lods=3,\n    multires_strategy='decimate',\n    decimation_factor=2,\n    # Lower than the production default (25,000) so these small toy meshes\n    # split into enough chunks for multires loading to be apparent in the viewer.\n    target_faces_per_lod0_chunk=2000,\n    delete_decimated_meshes=True,\n    do_analysis=False,\n    # Pack the multires output into <n>.shard files; see the section above.\n    sharded=True,\n)\nmeshify.get_meshes()\nprint('Meshes written to', output_dir)"
+   "source": "from mesh_n_bone.meshify.meshify import Meshify\n\noutput_dir = os.path.join(work_dir, 'output')\nif os.path.exists(output_dir):\n    shutil.rmtree(output_dir)\n\nmeshify = Meshify(\n    input_path=array_path,\n    output_directory=output_dir,\n    num_workers=1,\n    do_simplification=True,\n    target_reduction=0.5,\n    n_smoothing_iter=2,\n    check_mesh_validity=False,\n    do_multires=True,\n    num_lods=3,\n    multires_strategy='decimate',\n    decimation_factor=2,\n    # Lower than the production default (25,000) so these small toy meshes\n    # split into enough chunks for multires loading to be apparent in the viewer.\n    target_faces_per_lod0_chunk=2000,\n    delete_decimated_meshes=True,\n    do_analysis=False,\n    # Sharded multires output is on by default; pass sharded=False to opt out.\n)\nmeshify.get_meshes()\nprint('Meshes written to', output_dir)"
   },
   {
    "cell_type": "markdown",

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -29,7 +29,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%pip install --quiet --upgrade 'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git@smooth-before-decimate'"
+   "source": "%pip install --quiet --upgrade 'mesh-n-bone @ git+https://github.com/janelia-cellmap/mesh-n-bone.git@improve-efficiency'"
   },
   {
    "cell_type": "markdown",

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -3,19 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# mesh-n-bone end-to-end example\n",
-    "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/janelia-cellmap/mesh-n-bone/blob/master/examples/example.ipynb)\n",
-    "\n",
-    "Runs the full pipeline in one notebook:\n",
-    "1. Install the package\n",
-    "2. Create a 256³ zarr segmentation volume (sphere + torus + ridged blob)\n",
-    "3. Generate meshes and the multires Draco output\n",
-    "4. Launch a local neuroglancer viewer\n",
-    "\n",
-    "Works on a local machine or in Google Colab. Skeletonization is **not** included — it requires a separately compiled CGAL binary."
-   ]
+   "source": "# mesh-n-bone end-to-end example\n\n[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/janelia-cellmap/mesh-n-bone/blob/improve-efficiency/examples/example.ipynb)\n\nRuns the full pipeline in one notebook:\n1. Install the package\n2. Create a 256³ zarr segmentation volume (sphere + torus + ridged blob)\n3. Generate meshes and the multires Draco output\n4. Launch a local neuroglancer viewer\n\nWorks on a local machine or in Google Colab. Skeletonization is **not** included — it requires a separately compiled CGAL binary."
   },
   {
    "cell_type": "markdown",

--- a/pixi.lock
+++ b/pixi.lock
@@ -6073,8 +6073,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: .
   name: mesh-n-bone
-  version: 0.1.7
-  sha256: 250c51622e133a326f57a6385ce39588fa4c147051881839e0d743ec88be59ce
+  version: 0.3.0
+  sha256: 717df5262bfdba21de64fe3abf56f37cc7c21d6ab7e477a0a85d22c4f83d5f4b
   requires_dist:
   - numpy
   - trimesh>=4.6.8

--- a/src/mesh_n_bone/config.py
+++ b/src/mesh_n_bone/config.py
@@ -78,7 +78,7 @@ def read_multires_config(config_path):
             optional_properties_settings["segment_properties_id_column"] = "Object ID"
 
         sharding_settings = config.get("sharding_settings", {}) or {}
-        sharding_settings.setdefault("sharded", False)
+        sharding_settings.setdefault("sharded", True)
         sharding_settings.setdefault("preshift_bits", None)
         sharding_settings.setdefault("minishard_bits", None)
         sharding_settings.setdefault("shard_bits", None)

--- a/src/mesh_n_bone/meshify/fixed_edge.py
+++ b/src/mesh_n_bone/meshify/fixed_edge.py
@@ -432,6 +432,8 @@ def simplify_mesh(
     F = mesh.faces
     if len(F) == 0:
         return mesh
+    if target_reduction <= 0:
+        return repair_cleanup(mesh)
 
     target_faces = int(max(12, (1 - target_reduction) * F.shape[0]))
     if fix_edges:

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -863,7 +863,7 @@ class Meshify:
         voxel_size_nm: list = None,
         retry_on_oom: bool = True,
         memory_retry_max: int = 3,
-        sharded: bool = False,
+        sharded: bool = True,
         shard_bits: int | None = None,
         minishard_bits: int | None = None,
         preshift_bits: int | None = None,

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -153,6 +153,23 @@ def staged_reductions(target_reduction_total, frac1, frac2):
     return r1, r2
 
 
+def _chunk_stage_1_reduction(config):
+    """Return the chunk-level reduction for fixed-edge chunk processing.
+
+    ``use_fixed_edge_simplification=False`` means skip chunk-level
+    decimation, but still use the fixed-edge clipping path when global
+    simplification is enabled.
+    """
+    if not config["use_fixed_edge_simplification"]:
+        return 0.0
+    stage_1_reduction, _ = staged_reductions(
+        config["target_reduction"],
+        config["stage_1_reduction_fraction"],
+        1 - config["stage_1_reduction_fraction"],
+    )
+    return stage_1_reduction
+
+
 # Thread-local tensorstore handle cache so each worker opens once
 _thread_local_ts = {}
 
@@ -628,7 +645,7 @@ def _get_chunked_mesh_worker(block_index, tmpdirname, config):
         original_id = inv_remap[int(id)] if inv_remap is not None else int(id)
         mesh = mesher.get_mesh(id)
 
-        if config["use_fixed_edge_simplification"] and config["do_simplification"]:
+        if config["do_simplification"]:
             mesh_tri = trimesh.Trimesh(vertices=mesh.vertices, faces=mesh.faces)
             # Shift by half a voxel so clip planes in
             # remove_boundary_vertices land exactly on the MC crossing
@@ -640,12 +657,6 @@ def _get_chunked_mesh_worker(block_index, tmpdirname, config):
             half_pad = 0.5 * np.array(output_voxel_size)[::-1]
             mesh_tri.vertices -= half_pad
 
-            stage_1_reduction, _ = staged_reductions(
-                config["target_reduction"],
-                config["stage_1_reduction_fraction"],
-                1 - config["stage_1_reduction_fraction"],
-            )
-
             ds = config["downsample_factor"] or 1
             block_size_voxels = np.array(config["read_write_block_shape_pixels"]) // ds
             block_size_world = (block_size_voxels * output_voxel_size)[::-1]
@@ -653,7 +664,7 @@ def _get_chunked_mesh_worker(block_index, tmpdirname, config):
             mesh_tri_simplified = simplify_mesh(
                 mesh_tri,
                 voxel_size=output_voxel_size,
-                target_reduction=stage_1_reduction,
+                target_reduction=_chunk_stage_1_reduction(config),
                 block_size=block_size_world,
                 aggressiveness=config["default_aggressiveness"],
                 verbose=False,
@@ -1551,7 +1562,7 @@ class Meshify:
                 chunk_size=chunk_size[::-1],
                 offset=self.roi.offset[::-1],
             )
-            if self.use_fixed_edge_simplification:
+            if self.do_simplification:
                 # The half-voxel shift places clip planes on the MC
                 # crossing vertices between padding and unpadded voxels.
                 # Both adjacent blocks clip at the same world plane and

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -891,8 +891,9 @@ class Meshify:
         )
 
         def _run(workers, config):
-            # db.range chokes when npartitions > n; cap at the block count.
-            npartitions = max(1, min(num_blocks, workers * 10))
+            # Use the rounded estimator here rather than workers * 10 directly:
+            # dask.bag.range puts all remainder elements in the final partition.
+            npartitions = dask_util.guesstimate_npartitions(num_blocks, workers)
             bag = db.range(num_blocks, npartitions=npartitions).map(
                 _get_chunked_mesh_worker, dirname, worker_config
             )

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -158,19 +158,27 @@ _thread_local_ts = {}
 def _estimate_block_target_mb_from_dask_config(
     config_path="dask-config.yaml",
     fallback_mb=128,
-    cap_mb=1024,
-    processing_amplification=8,
+    processing_amplification=16,
 ):
-    """Pick a per-block memory budget based on per-worker RAM.
+    """Pick a per-block memory budget by working backward from worker RAM.
 
-    Reads ``dask-config.yaml`` from the current directory, extracts
-    per-worker memory (``memory / processes`` for the configured cluster
-    type), and returns a fraction of it sized to leave headroom for
-    processing (MC working memory + stage-1 simplification scratch).
+    Reads ``dask-config.yaml`` and divides per-worker memory by an
+    amplification factor that approximates "peak working memory ÷
+    voxel-array memory" for a block (block input + tensorstore
+    decompression buffer + zmesh internal tables + per-chunk
+    simplification scratch + Python/library baseline). 16 is
+    deliberately conservative so a dense block can't OOM the worker
+    even at peak.
 
-    Returns *fallback_mb* if the config can't be found or parsed —
-    keeping the heuristic safely conservative on machines without a
-    dask config (e.g. local single-process runs).
+    Returns *fallback_mb* if the dask config is missing/unparseable —
+    keeping behavior identical to pre-auto-tune on local/test runs.
+
+    For the user's typical LSF config (180 GB / 12 processes = 15 GB
+    per worker), this yields ~937 MB per block. For a 60 GB-per-worker
+    box it'd give ~3.75 GB; there is no extra ceiling cap because
+    the amplification factor already encodes "leave headroom" — adding
+    a cap on top hides the math and makes the result harder to reason
+    about.
 
     Parameters
     ----------
@@ -178,14 +186,10 @@ def _estimate_block_target_mb_from_dask_config(
         Path to dask-config.yaml. Default reads from cwd.
     fallback_mb : int
         Returned when the dask config is missing or unparseable.
-    cap_mb : int
-        Upper bound. Even on huge-memory workers we don't want any
-        single block too big — one slow block tails the whole run, and
-        peak working memory still has to fit.
     processing_amplification : int
-        Heuristic multiplier for "block peak RAM / block voxel array."
-        zmesh + stage-1 simplification typically uses ~5-8x the voxel
-        array; 8 is conservative.
+        "Block peak RAM ÷ block voxel array" multiplier. zmesh + stage-1
+        simplification typically uses ~6-10x; we use 16 to leave room
+        for dense degenerate cases.
     """
     try:
         from dask.utils import parse_bytes
@@ -201,7 +205,8 @@ def _estimate_block_target_mb_from_dask_config(
         processes = int(settings.get("processes") or 1)
         per_worker_mb = (mem_bytes / processes) / 1e6
         target = per_worker_mb / processing_amplification
-        return float(min(cap_mb, max(fallback_mb, target)))
+        # Floor so tiny workers don't get pathologically small blocks.
+        return float(max(fallback_mb, target))
     except (FileNotFoundError, KeyError, TypeError, ValueError):
         return fallback_mb
 

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -155,6 +155,57 @@ def staged_reductions(target_reduction_total, frac1, frac2):
 _thread_local_ts = {}
 
 
+def _estimate_block_target_mb_from_dask_config(
+    config_path="dask-config.yaml",
+    fallback_mb=128,
+    cap_mb=1024,
+    processing_amplification=8,
+):
+    """Pick a per-block memory budget based on per-worker RAM.
+
+    Reads ``dask-config.yaml`` from the current directory, extracts
+    per-worker memory (``memory / processes`` for the configured cluster
+    type), and returns a fraction of it sized to leave headroom for
+    processing (MC working memory + stage-1 simplification scratch).
+
+    Returns *fallback_mb* if the config can't be found or parsed —
+    keeping the heuristic safely conservative on machines without a
+    dask config (e.g. local single-process runs).
+
+    Parameters
+    ----------
+    config_path : str
+        Path to dask-config.yaml. Default reads from cwd.
+    fallback_mb : int
+        Returned when the dask config is missing or unparseable.
+    cap_mb : int
+        Upper bound. Even on huge-memory workers we don't want any
+        single block too big — one slow block tails the whole run, and
+        peak working memory still has to fit.
+    processing_amplification : int
+        Heuristic multiplier for "block peak RAM / block voxel array."
+        zmesh + stage-1 simplification typically uses ~5-8x the voxel
+        array; 8 is conservative.
+    """
+    try:
+        from dask.utils import parse_bytes
+        import yaml
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f)
+        jq = cfg.get("jobqueue", {}) or {}
+        if not jq:
+            return fallback_mb
+        # Take the first (only) configured cluster type.
+        _, settings = next(iter(jq.items()))
+        mem_bytes = parse_bytes(str(settings["memory"]))
+        processes = int(settings.get("processes") or 1)
+        per_worker_mb = (mem_bytes / processes) / 1e6
+        target = per_worker_mb / processing_amplification
+        return float(min(cap_mb, max(fallback_mb, target)))
+    except (FileNotFoundError, KeyError, TypeError, ValueError):
+        return fallback_mb
+
+
 def _normalize_target_ids(value):
     """Coerce a target_ids spec to a frozenset[int] or None.
 
@@ -181,21 +232,34 @@ def _normalize_target_ids(value):
     return frozenset(int(i) for i in value)
 
 
-def _get_chunked_mesh_worker(block, tmpdirname, config):
+def _get_chunked_mesh_worker(block_index, tmpdirname, config):
     """Run marching cubes on a single block and write per-segment PLYs.
 
     This is a module-level function so only lightweight *config* dict
     (scalars, tuples, strings) is serialised to workers — no zarr arrays.
+    Receives only the block's sequential index; the block's ROI is
+    materialized inside the worker via
+    :func:`mesh_n_bone.util.dask_util.block_from_index`, so the driver
+    never has to hold a list of millions of block objects.
 
     Parameters
     ----------
-    block : DaskBlock
-        Block specification with ROI and index.
+    block_index : int
+        Sequential block index produced by ``db.range(num_blocks)``.
     tmpdirname : str
         Temporary directory for writing per-segment block meshes.
     config : dict
-        Worker config from ``Meshify._get_worker_config()``.
+        Worker config from ``Meshify._get_worker_config()``. Must
+        include ``block_roi_begin``, ``block_roi_end``,
+        ``block_size_world`` and ``block_padding``.
     """
+    block = dask_util.block_from_index(
+        block_index,
+        config["block_roi_begin"],
+        config["block_roi_end"],
+        config["block_size_world"],
+        padding=config.get("block_padding"),
+    )
     dataset_path = config["dataset_path"]
     if dataset_path not in _thread_local_ts:
         _thread_local_ts[dataset_path] = open_ds_tensorstore(dataset_path)
@@ -658,24 +722,36 @@ class Meshify:
         self.retry_on_oom = retry_on_oom
         self.memory_retry_max = memory_retry_max
 
-    def _default_block_shape_pixels(self, target_mb=128):
+    def _default_block_shape_pixels(self, target_mb=None):
         """Choose a default block shape as a chunk-aligned multiple.
 
         Picks the largest integer multiple of the dataset's chunk shape
-        whose memory footprint stays at or below ``target_mb``.  Larger
+        whose memory footprint stays at or below ``target_mb``. Larger
         blocks reduce the number of block boundaries (and therefore
-        frozen boundary vertices during fixed-edge simplification).
+        frozen boundary vertices during fixed-edge simplification),
+        and shrink dask graph scheduling overhead.
+
+        When ``target_mb`` is ``None`` (the default) we estimate a
+        sensible value from the dask-config.yaml in the current
+        directory: per-worker RAM divided by an empirical processing
+        amplification factor (~8x, covering MC working memory + stage-1
+        simplification scratch + headroom for Python/libs). Capped at
+        1 GB so a single slow block doesn't tail the whole run. Falls
+        back to 128 MB if no dask-config can be parsed.
 
         Parameters
         ----------
-        target_mb : int or float
-            Target memory budget per block in megabytes.
+        target_mb : int, float, or None
+            Target memory budget per block in megabytes. ``None``
+            triggers auto-tuning from the dask-config.
 
         Returns
         -------
         numpy.ndarray
             Block shape in voxels, as a multiple of the chunk shape.
         """
+        if target_mb is None:
+            target_mb = _estimate_block_target_mb_from_dask_config()
         chunk = np.array(self.segmentation_array.chunk_shape)
         itemsize = self.segmentation_array.dtype.itemsize
         chunk_bytes = int(np.prod(chunk)) * itemsize
@@ -777,31 +853,46 @@ class Meshify:
     def get_chunked_meshes(self, dirname):
         """Generate per-block meshes for the entire ROI using Dask.
 
+        Driver enumerates blocks lazily by index — only the count is
+        computed up front (O(1)), and each worker materializes its own
+        block ROI from the index. This avoids building a list of
+        millions of block objects on the driver for large volumes, and
+        shrinks per-task graph payload from a Roi-carrying object down
+        to a single int.
+
         Parameters
         ----------
         dirname : str
             Directory where per-segment block mesh PLYs are written.
         """
-        blocks = dask_util.create_blocks(
-            self.roi,
-            self.segmentation_array,
-            self.read_write_block_shape_pixels.copy(),
-            padding=self.output_voxel_size_funlib,
+        block_size_world = (
+            self.read_write_block_shape_pixels * self.output_voxel_size_funlib
         )
+        num_blocks = dask_util.count_blocks(self.roi, block_size_world)
 
         worker_config = self._get_worker_config()
+        # Pass enough info to reconstruct each block's ROI in the worker.
+        worker_config["block_roi_begin"] = tuple(self.roi.get_begin())
+        worker_config["block_roi_end"] = tuple(self.roi.get_end())
+        worker_config["block_size_world"] = tuple(int(v) for v in block_size_world)
+        worker_config["block_padding"] = tuple(self.output_voxel_size_funlib)
+
         effective_workers = dask_util.effective_num_workers(
-            self.num_workers, len(blocks), logger, "generate chunked meshes",
+            self.num_workers, num_blocks, logger, "generate chunked meshes",
         )
 
         def _run(workers, config):
-            bag = db.from_sequence(blocks, npartitions=workers * 10).map(
+            # db.range chokes when npartitions > n; cap at the block count.
+            npartitions = max(1, min(num_blocks, workers * 10))
+            bag = db.range(num_blocks, npartitions=npartitions).map(
                 _get_chunked_mesh_worker, dirname, worker_config
             )
             with dask_util.start_dask(
                 workers, "generate chunked meshes", logger, config=config,
             ):
-                with Timing_Messager("Generating chunked meshes", logger):
+                with Timing_Messager(
+                    f"Generating chunked meshes ({num_blocks} blocks)", logger,
+                ):
                     bag.compute()
 
         dask_util.run_with_oom_retry(

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -1600,7 +1600,7 @@ class Meshify:
 
         try:
             if self.use_fixed_edge_simplification and self.do_simplification:
-                stage_2_reduction, _ = staged_reductions(
+                _, stage_2_reduction = staged_reductions(
                     self.target_reduction,
                     self.stage_1_reduction_fraction,
                     self.stage_2_reduction_fraction,

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -569,7 +569,7 @@ def _get_chunked_mesh_worker(block_index, tmpdirname, config):
     mesher = Mesher(output_voxel_size[::-1])
     segmentation_block = to_ndarray_tensorstore(
         ts_dataset, block.roi, voxel_size, roi_offset,
-        swap_axes=config["swap_axes"], fill_value=0,
+        swap_axes=config["swap_axes"], fill_value=0, source_path=dataset_path,
     )
     if segmentation_block.dtype.byteorder == ">":
         swapped_dtype = segmentation_block.dtype.newbyteorder()

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -158,38 +158,42 @@ _thread_local_ts = {}
 def _estimate_block_target_mb_from_dask_config(
     config_path="dask-config.yaml",
     fallback_mb=128,
-    processing_amplification=16,
+    processing_amplification=6,
 ):
     """Pick a per-block memory budget by working backward from worker RAM.
 
     Reads ``dask-config.yaml`` and divides per-worker memory by an
-    amplification factor that approximates "peak working memory ÷
-    voxel-array memory" for a block (block input + tensorstore
-    decompression buffer + zmesh internal tables + per-chunk
-    simplification scratch + Python/library baseline). 16 is
-    deliberately conservative so a dense block can't OOM the worker
-    even at peak.
+    amplification factor approximating "peak working memory ÷ voxel-array
+    memory" for a block.
 
-    Returns *fallback_mb* if the dask config is missing/unparseable —
-    keeping behavior identical to pre-auto-tune on local/test runs.
+    The default amplification (6) is set from an empirical RSS-peak
+    measurement across uint64 block sizes 32 MB → 512 MB at sparse (10
+    segments) and dense (1000 segments) densities. After subtracting the
+    fixed ~114 MB Python + zmesh + pymeshlab + trimesh import baseline,
+    the asymptotic amplification was ~0.1× on sparse blocks and
+    ~1.1–1.3× on dense blocks — i.e., per-task peak working memory grows
+    almost exactly with the voxel array on dense data and not at all on
+    sparse data. ``6`` leaves a ~4.5× safety margin over the empirical
+    worst case for unforeseen dense / degenerate cases.
 
-    For the user's typical LSF config (180 GB / 12 processes = 15 GB
-    per worker), this yields ~937 MB per block. For a 60 GB-per-worker
-    box it'd give ~3.75 GB; there is no extra ceiling cap because
-    the amplification factor already encodes "leave headroom" — adding
-    a cap on top hides the math and makes the result harder to reason
-    about.
+    For the user's typical LSF config (180 GB / 12 processes = 15 GB per
+    worker) this yields ~2.5 GB per block; for a 60 GB-per-worker box
+    it'd give ~10 GB. No cap — the amplification factor already encodes
+    "leave headroom" and a cap on top would hide the math.
+
+    Returns *fallback_mb* if the dask config is missing/unparseable.
 
     Parameters
     ----------
     config_path : str
         Path to dask-config.yaml. Default reads from cwd.
     fallback_mb : int
-        Returned when the dask config is missing or unparseable.
+        Returned when the dask config is missing or unparseable. Also
+        the floor on the auto-tuned result so tiny workers don't get
+        pathologically small blocks.
     processing_amplification : int
-        "Block peak RAM ÷ block voxel array" multiplier. zmesh + stage-1
-        simplification typically uses ~6-10x; we use 16 to leave room
-        for dense degenerate cases.
+        "Block peak RAM ÷ block voxel array" multiplier. Empirical
+        asymptote is ~1.3×; the 6× default is 4.5× safety margin.
     """
     try:
         from dask.utils import parse_bytes

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -1,5 +1,7 @@
 """Mesh generation from segmentation volumes using zmesh and dask."""
 
+from dataclasses import asdict, dataclass
+import copy
 from funlib.geometry import Roi, Coordinate
 import numpy as np
 import os
@@ -153,6 +155,292 @@ def staged_reductions(target_reduction_total, frac1, frac2):
 
 # Thread-local tensorstore handle cache so each worker opens once
 _thread_local_ts = {}
+
+
+@dataclass(frozen=True)
+class AssemblyMeshEstimate:
+    """Estimated assembly cost for one final segment mesh."""
+
+    mesh_id: str
+    num_files: int
+    ply_bytes: int
+    vertex_count: int
+    face_count: int
+    raw_mesh_bytes: int
+    estimated_peak_bytes: int
+
+
+@dataclass(frozen=True)
+class AssemblyWave:
+    """One assembly pass using a single Dask process-per-job setting."""
+
+    processes: int
+    workers: int
+    batches: list[list[str]]
+    max_estimated_peak_bytes: int
+    total_ply_bytes: int
+    config: dict | None
+
+
+def _read_ply_header_counts(path, max_header_bytes=64 * 1024):
+    """Return ``(vertices, faces)`` from a PLY header without reading geometry."""
+    header = bytearray()
+    marker = b"end_header"
+    with open(path, "rb") as f:
+        while marker not in header and len(header) < max_header_bytes:
+            chunk = f.read(1024)
+            if not chunk:
+                break
+            header.extend(chunk)
+
+    end = header.find(marker)
+    if end < 0:
+        raise ValueError(f"PLY header terminator not found in {path!r}")
+
+    text = header[:end].decode("ascii", errors="ignore")
+    vertices = None
+    faces = None
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) == 3 and parts[:2] == ["element", "vertex"]:
+            vertices = int(parts[2])
+        elif len(parts) == 3 and parts[:2] == ["element", "face"]:
+            faces = int(parts[2])
+
+    if vertices is None or faces is None:
+        raise ValueError(f"PLY vertex/face counts not found in {path!r}")
+    return vertices, faces
+
+
+def _assembly_memory_amplification(
+    do_simplification=True,
+    smooth_before_simplify=True,
+    check_mesh_validity=True,
+    has_custom_roi=False,
+):
+    """Choose a conservative peak-RSS multiplier for assembled mesh arrays."""
+    if do_simplification:
+        # A 658 MiB / 31M-face chunked PLY sample measured 16.6 GiB peak
+        # RSS for decimate-then-smooth assembly without validity repair.
+        # That is ~22x over raw float64/int32 mesh arrays after the fixed
+        # baseline, so keep a little headroom above the observed case.
+        amplification = 32 if smooth_before_simplify else 24
+    else:
+        # Even without simplification, concatenate/consolidate/boundary
+        # dedup can briefly duplicate several full-size mesh arrays.
+        amplification = 20
+    if check_mesh_validity or has_custom_roi:
+        amplification += 4
+    return amplification
+
+
+def _estimate_assembly_peak_bytes(
+    ply_bytes,
+    vertex_count,
+    face_count,
+    amplification,
+    baseline_bytes=1 << 30,
+):
+    """Estimate peak RSS for one mesh assembly from chunk PLY totals."""
+    raw_mesh_bytes = vertex_count * 3 * 8 + face_count * 3 * 4
+    # Header parsing can fail for malformed or future PLY variants. In that
+    # case, file size is still a useful lower bound on in-memory geometry.
+    effective_mesh_bytes = max(raw_mesh_bytes, int(ply_bytes * 1.1))
+    return raw_mesh_bytes, int(baseline_bytes + amplification * effective_mesh_bytes)
+
+
+def _scan_assembly_mesh_estimates(dirname, amplification):
+    """Scan chunked mesh PLYs and estimate assembly memory per segment id."""
+    estimates = []
+    for mesh_id in sorted(os.listdir(dirname)):
+        mesh_dir = os.path.join(dirname, mesh_id)
+        if not os.path.isdir(mesh_dir):
+            continue
+
+        num_files = 0
+        ply_bytes = 0
+        vertex_count = 0
+        face_count = 0
+        for name in os.listdir(mesh_dir):
+            if not name.endswith(".ply"):
+                continue
+            num_files += 1
+            path = os.path.join(mesh_dir, name)
+            try:
+                ply_bytes += os.path.getsize(path)
+                vertices, faces = _read_ply_header_counts(path)
+            except (OSError, ValueError) as e:
+                logger.debug("Could not read PLY header for %s: %s", path, e)
+                continue
+            vertex_count += vertices
+            face_count += faces
+
+        if num_files == 0:
+            continue
+        raw_mesh_bytes, estimated_peak_bytes = _estimate_assembly_peak_bytes(
+            ply_bytes, vertex_count, face_count, amplification,
+        )
+        estimates.append(
+            AssemblyMeshEstimate(
+                mesh_id=str(mesh_id),
+                num_files=num_files,
+                ply_bytes=int(ply_bytes),
+                vertex_count=int(vertex_count),
+                face_count=int(face_count),
+                raw_mesh_bytes=int(raw_mesh_bytes),
+                estimated_peak_bytes=int(estimated_peak_bytes),
+            )
+        )
+    return estimates
+
+
+def _jobqueue_settings(config):
+    """Return ``(cluster_type, settings)`` for a dask-jobqueue config."""
+    if not config:
+        return None, None
+    jobqueue = config.get("jobqueue", {}) or {}
+    if not jobqueue:
+        return None, None
+    cluster_type, settings = next(iter(jobqueue.items()))
+    return cluster_type, settings
+
+
+def _job_memory_bytes(settings):
+    """Parse job memory bytes from a dask-jobqueue settings dict."""
+    if not settings or "memory" not in settings:
+        return None
+    from dask.utils import parse_bytes
+    return int(parse_bytes(str(settings["memory"])))
+
+
+def _recommended_assembly_processes(
+    estimated_peak_bytes,
+    job_memory_bytes,
+    base_processes,
+    memory_fraction=0.60,
+):
+    """Pick processes/job so one estimated assembly fits per process."""
+    base_processes = max(1, int(base_processes))
+    if not job_memory_bytes or estimated_peak_bytes <= 0:
+        return base_processes
+    usable_job_bytes = int(job_memory_bytes * memory_fraction)
+    processes = usable_job_bytes // int(estimated_peak_bytes)
+    return max(1, min(base_processes, int(processes)))
+
+
+def _assembly_config_for_processes(config, cluster_type, processes):
+    """Copy a Dask config and set processes/cores for one-thread workers."""
+    if config is None or cluster_type is None:
+        return None
+    adjusted = copy.deepcopy(config)
+    dask_util.set_jobqueue_processes(adjusted, cluster_type, processes)
+    return adjusted
+
+
+def _balanced_assembly_batches(estimates, max_batches):
+    """Greedily balance mesh ids into batches by estimated processing weight."""
+    import heapq
+
+    if not estimates:
+        return []
+    max_batches = max(1, min(int(max_batches), len(estimates)))
+    heap = [(0, i, []) for i in range(max_batches)]
+    weights_by_id = {}
+    for estimate in estimates:
+        weights_by_id[estimate.mesh_id] = max(
+            estimate.estimated_peak_bytes, estimate.ply_bytes, 1,
+        )
+    for estimate in sorted(
+        estimates, key=lambda e: weights_by_id[e.mesh_id], reverse=True,
+    ):
+        weight, index, mesh_ids = heapq.heappop(heap)
+        mesh_ids = mesh_ids + [estimate.mesh_id]
+        heapq.heappush(
+            heap, (weight + weights_by_id[estimate.mesh_id], index, mesh_ids)
+        )
+
+    batches = [mesh_ids for weight, index, mesh_ids in heap if mesh_ids]
+    batches.sort(
+        key=lambda ids: sum(weights_by_id[mesh_id] for mesh_id in ids),
+        reverse=True,
+    )
+    return batches
+
+
+def _plan_assembly_waves(
+    estimates,
+    requested_workers,
+    config=None,
+    batches_per_worker=4,
+    memory_fraction=0.60,
+):
+    """Group mesh ids into assembly waves with memory-aware Dask configs."""
+    if not estimates:
+        return []
+
+    cluster_type, settings = _jobqueue_settings(config)
+    base_processes = int((settings or {}).get("processes", 1) or 1)
+    job_memory = _job_memory_bytes(settings)
+
+    estimates_by_processes = {}
+    for estimate in estimates:
+        processes = _recommended_assembly_processes(
+            estimate.estimated_peak_bytes,
+            job_memory,
+            base_processes,
+            memory_fraction=memory_fraction,
+        )
+        estimates_by_processes.setdefault(processes, []).append(estimate)
+
+    waves = []
+    requested_workers = max(1, int(requested_workers))
+    for processes in sorted(estimates_by_processes):
+        wave_estimates = estimates_by_processes[processes]
+        nominal_workers = max(
+            1, requested_workers * int(processes) // max(1, base_processes)
+        )
+        max_batches = max(1, nominal_workers * int(batches_per_worker))
+        batches = _balanced_assembly_batches(wave_estimates, max_batches)
+        # Keep enough workers to fill one job when processes > task count.
+        workers = min(nominal_workers, max(len(batches), int(processes)))
+        waves.append(
+            AssemblyWave(
+                processes=int(processes),
+                workers=int(max(1, workers)),
+                batches=batches,
+                max_estimated_peak_bytes=max(
+                    e.estimated_peak_bytes for e in wave_estimates
+                ),
+                total_ply_bytes=sum(e.ply_bytes for e in wave_estimates),
+                config=_assembly_config_for_processes(
+                    config, cluster_type, int(processes)
+                ),
+            )
+        )
+    return waves
+
+
+def _write_assembly_memory_plan(output_directory, estimates, waves):
+    """Write a small JSON record explaining the assembly scheduling plan."""
+    plan = {
+        "mesh_estimates": [asdict(e) for e in estimates],
+        "waves": [
+            {
+                "processes": wave.processes,
+                "workers": wave.workers,
+                "num_batches": len(wave.batches),
+                "num_meshes": sum(len(batch) for batch in wave.batches),
+                "max_estimated_peak_bytes": wave.max_estimated_peak_bytes,
+                "total_ply_bytes": wave.total_ply_bytes,
+                "batches": wave.batches,
+            }
+            for wave in waves
+        ],
+    }
+    plan_dir = os.path.join(output_directory, "assembly_metadata")
+    os.makedirs(plan_dir, exist_ok=True)
+    with open(os.path.join(plan_dir, "assembly_memory_plan.json"), "w") as f:
+        json.dump(plan, f, indent=2)
 
 
 def _estimate_block_target_mb_from_dask_config(
@@ -1379,6 +1667,11 @@ class Meshify:
             _ = mesh.export(f"{self.output_directory}/meshes/{mesh_id}.ply")
         shutil.rmtree(f"{self.dirname}/{mesh_id}")
 
+    def _assemble_mesh_batch(self, mesh_ids):
+        """Assemble a memory-balanced batch of segment ids sequentially."""
+        for mesh_id in mesh_ids:
+            self._assemble_mesh(mesh_id)
+
     def assemble_meshes(self, dirname):
         """Assemble all per-segment block meshes and write final outputs.
 
@@ -1394,32 +1687,80 @@ class Meshify:
 
         os.makedirs(f"{self.output_directory}/meshes/", exist_ok=True)
         self.dirname = dirname
-        mesh_ids = os.listdir(dirname)
+        amplification = _assembly_memory_amplification(
+            do_simplification=self.do_simplification,
+            smooth_before_simplify=self.smooth_before_simplify,
+            check_mesh_validity=self.check_mesh_validity,
+            has_custom_roi=self.has_custom_roi,
+        )
+        estimates = _scan_assembly_mesh_estimates(dirname, amplification)
+        if not estimates:
+            logger.warning("No chunked mesh PLYs found in %s; skipping assembly.", dirname)
+            shutil.rmtree(dirname, ignore_errors=True)
+            return
+
+        assembly_config = None
+        if self.num_workers > 1:
+            try:
+                assembly_config = dask_util._load_dask_config()
+            except (FileNotFoundError, KeyError, TypeError, ValueError) as e:
+                logger.warning(
+                    "Could not load dask-config.yaml for assembly memory "
+                    "planning (%s); using default worker count.",
+                    e,
+                )
+
+        waves = _plan_assembly_waves(
+            estimates, self.num_workers, config=assembly_config,
+        )
+        _write_assembly_memory_plan(self.output_directory, estimates, waves)
+
+        largest = max(estimates, key=lambda e: e.estimated_peak_bytes)
+        logger.info(
+            "Assembly memory estimate: largest mesh_id=%s, chunked_ply=%.1f MiB, "
+            "raw_mesh=%.1f MiB, estimated_peak=%.1f GiB, amplification=%sx.",
+            largest.mesh_id,
+            largest.ply_bytes / 2**20,
+            largest.raw_mesh_bytes / 2**20,
+            largest.estimated_peak_bytes / 2**30,
+            amplification,
+        )
+        for i, wave in enumerate(waves, start=1):
+            logger.info(
+                "Assembly wave %d/%d: processes/job=%d, workers=%d, "
+                "batches=%d, meshes=%d, max_estimated_peak=%.1f GiB.",
+                i, len(waves), wave.processes, wave.workers, len(wave.batches),
+                sum(len(batch) for batch in wave.batches),
+                wave.max_estimated_peak_bytes / 2**30,
+            )
+
         # Drop the zarr-backed array before dask serialises self — assembly
         # only reads PLY files, not the segmentation volume.
         saved_array = self.segmentation_array
         self.segmentation_array = None
-        effective_workers = dask_util.effective_num_workers(
-            self.num_workers, len(mesh_ids), logger, "assemble meshes",
-        )
-
-        def _run(workers, config):
-            bag = db.from_sequence(
-                mesh_ids,
-                npartitions=dask_util.guesstimate_npartitions(mesh_ids, workers),
-            ).map(self._assemble_mesh)
-            with dask_util.start_dask(
-                workers, "assemble meshes", logger, config=config,
-            ):
-                with Timing_Messager("Assembling meshes", logger):
-                    bag.compute()
 
         try:
-            dask_util.run_with_oom_retry(
-                _run, effective_workers, "assemble meshes", logger,
-                max_retries=self.memory_retry_max,
-                retry_on_oom=self.retry_on_oom,
-            )
+            for i, wave in enumerate(waves, start=1):
+                phase_name = f"assemble meshes wave {i}/{len(waves)}"
+
+                def _run(workers, config, wave=wave, phase_name=phase_name):
+                    bag = db.from_sequence(
+                        wave.batches, npartitions=len(wave.batches),
+                    ).map(self._assemble_mesh_batch)
+                    with dask_util.start_dask(
+                        workers, phase_name, logger, config=config,
+                    ):
+                        with Timing_Messager(
+                            f"Assembling meshes ({phase_name})", logger,
+                        ):
+                            bag.compute()
+
+                dask_util.run_with_oom_retry(
+                    _run, wave.workers, phase_name, logger,
+                    max_retries=self.memory_retry_max,
+                    retry_on_oom=self.retry_on_oom,
+                    config=wave.config,
+                )
         finally:
             self.segmentation_array = saved_array
         if self.do_legacy_neuroglancer:
@@ -1531,13 +1872,14 @@ class Meshify:
                     continue
                 name = entry.name
                 root, ext = os.path.splitext(name)
-                if mesh_ext is None:
-                    mesh_ext = ext
                 try:
-                    mesh_ids.append(int(root))
-                    file_sizes.append(entry.stat(follow_symlinks=False).st_size)
+                    mesh_id = int(root)
                 except ValueError:
                     continue
+                if mesh_ext is None:
+                    mesh_ext = ext
+                mesh_ids.append(mesh_id)
+                file_sizes.append(entry.stat(follow_symlinks=False).st_size)
 
         if not mesh_ids:
             logger.warning("No meshes found at s0, skipping multires generation")

--- a/src/mesh_n_bone/multires/multires.py
+++ b/src/mesh_n_bone/multires/multires.py
@@ -71,7 +71,11 @@ def generate_neuroglancer_multires_mesh(
         vertex_max = None
         lod_vertex_mins = []
         lod_vertex_maxs = []
+        requested_lods = list(lods)
+        requested_lod_count = len(requested_lods)
+        lod_face_counts = []
         previous_num_faces = np.inf
+        lod_truncation_reason = None
         for idx, current_lod in enumerate(lods):
             if current_lod == 0:
                 mesh_path = f"{output_path}/mesh_lods/s{current_lod}/{id}{original_ext}"
@@ -80,11 +84,24 @@ def generate_neuroglancer_multires_mesh(
 
             vertices, faces = mesh_io.mesh_loader(mesh_path)
             if faces is None:
+                lod_truncation_reason = (
+                    f"Segment {id} using {idx}/{requested_lod_count} requested "
+                    f"LODs; dropping LOD {current_lod} and later because "
+                    f"{mesh_path} could not be loaded or has no faces."
+                )
                 break
 
             num_faces = len(faces)
             if num_faces >= previous_num_faces:
+                previous_lod, previous_faces = lod_face_counts[-1]
+                lod_truncation_reason = (
+                    f"Segment {id} using {idx}/{requested_lod_count} requested "
+                    f"LODs; dropping LOD {current_lod} and later because it "
+                    f"has {num_faces} faces, not fewer than LOD "
+                    f"{previous_lod} ({previous_faces} faces)."
+                )
                 break
+            lod_face_counts.append((current_lod, num_faces))
             # LOD-0 bounds drive the chunk grid; union bounds drive
             # the empty-placeholder envelope (which must cover every
             # LOD's actual face footprint, not just LOD 0's).
@@ -113,6 +130,16 @@ def generate_neuroglancer_multires_mesh(
             idx += 1
 
         lods = lods[:idx]
+        if lod_truncation_reason is not None:
+            logger.info(lod_truncation_reason)
+        if not lods:
+            logger.warning(
+                "Segment %s has no valid LOD meshes from requested LODs %s; "
+                "skipping Neuroglancer multires output.",
+                id,
+                requested_lods,
+            )
+            return
 
         auto_lod_0_box_size = lod_0_box_size is None
         if lod_0_box_size is None:
@@ -138,6 +165,7 @@ def generate_neuroglancer_multires_mesh(
         if auto_lod_0_box_size:
             requested_lod_count = len(lods)
             effective_lod_count = requested_lod_count
+            padding_candidates = []
             for candidate_lod_count in range(requested_lod_count, 0, -1):
                 octree_unit = 2 ** (candidate_lod_count - 1)
                 padded_chunks_per_axis = (
@@ -147,17 +175,44 @@ def generate_neuroglancer_multires_mesh(
                 padding_ratio = np.max(
                     padded_chunks_per_axis / num_chunks_per_axis
                 )
+                padding_candidates.append(
+                    (
+                        candidate_lod_count,
+                        padded_chunks_per_axis,
+                        padding_ratio,
+                    )
+                )
                 if padding_ratio <= MAX_AUTO_LOD_GRID_PADDING_RATIO:
                     effective_lod_count = candidate_lod_count
                     break
 
             if effective_lod_count < requested_lod_count:
+                requested_padding = padding_candidates[0]
+                selected_padding = next(
+                    candidate
+                    for candidate in padding_candidates
+                    if candidate[0] == effective_lod_count
+                )
                 logger.info(
-                    "Reducing segment %s from %d to %d LODs for auto chunking "
-                    "to keep the multires grid padding <= %.1fx",
+                    "Reducing segment %s from %d to %d LODs for auto chunking: "
+                    "LOD0 faces=%d, target_faces_per_lod0_chunk=%d, "
+                    "auto_box_size=%s, mesh_extent=%s, lod0_grid=%s. "
+                    "Requested %d LODs would pad the grid to %s (%.2fx); "
+                    "selected %d LODs pads to %s (%.2fx), max_allowed=%.2fx.",
                     id,
                     requested_lod_count,
                     effective_lod_count,
+                    int(lod0_num_faces),
+                    int(target_faces_per_lod0_chunk),
+                    np.asarray(lod_0_box_size).astype(float).tolist(),
+                    np.asarray(mesh_extent).astype(float).tolist(),
+                    np.asarray(num_chunks_per_axis).astype(int).tolist(),
+                    requested_padding[0],
+                    np.asarray(requested_padding[1]).astype(int).tolist(),
+                    float(requested_padding[2]),
+                    selected_padding[0],
+                    np.asarray(selected_padding[1]).astype(int).tolist(),
+                    float(selected_padding[2]),
                     MAX_AUTO_LOD_GRID_PADDING_RATIO,
                 )
                 lods = lods[:effective_lod_count]

--- a/src/mesh_n_bone/util/dask_util.py
+++ b/src/mesh_n_bone/util/dask_util.py
@@ -96,6 +96,14 @@ def start_dask(num_workers, msg, logger, config=None):
         with open("dask-config.yaml") as f:
             config = yaml.load(f, Loader=SafeLoader)
 
+    # Pin every common thread-pool source to a single thread per worker.
+    # OMP/MKL/OPENBLAS/NUMEXPR cover numpy/scipy/BLAS; TBB covers pymeshlab
+    # and meshlab's internal C++ filters (Taubin smoothing, vertex merge,
+    # etc.) which ignore the OMP family. Without TBB_NUM_THREADS each
+    # process can spawn ~N_CPU TBB workers during stage-2 simplification,
+    # which together with the dozens of dask workers stacked on a single
+    # LSF host trivially overwhelms the node (observed load avg >1000 on
+    # a 96-core box with 60 workers prior to this change).
     job_script_prologue = [
         "export NUMEXPR_MAX_THREADS=1",
         "export NUMEXPR_NUM_THREADS=1",
@@ -104,6 +112,9 @@ def start_dask(num_workers, msg, logger, config=None):
         "export OPENBLAS_NUM_THREADS=1",
         "export OPENMP_NUM_THREADS=1",
         "export OMP_NUM_THREADS=1",
+        "export TBB_NUM_THREADS=1",
+        # Some Intel runtimes have a separate KMP threadcount knob.
+        "export KMP_NUM_THREADS=1",
     ]
 
     cluster_type = next(iter(config["jobqueue"]))

--- a/src/mesh_n_bone/util/dask_util.py
+++ b/src/mesh_n_bone/util/dask_util.py
@@ -17,6 +17,35 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _close_dask_client(client, msg, logger):
+    """Best-effort shutdown for a Dask client/cluster.
+
+    Dask-jobqueue can occasionally report a worker as still running while the
+    cluster is already being torn down. Treat that as cleanup noise so a
+    completed compute stage does not fail the whole pipeline.
+    """
+    if client is None:
+        return
+
+    try:
+        client.shutdown()
+    except Exception as e:
+        logger.warning(
+            "Continuing after Dask shutdown failed for %s: %s",
+            msg,
+            e,
+        )
+
+    try:
+        client.close()
+    except Exception as e:
+        logger.warning(
+            "Continuing after Dask client close failed for %s: %s",
+            msg,
+            e,
+        )
+
+
 def set_local_directory(cluster_type):
     """Configure a writable local-directory for Dask worker spill and temp files.
 
@@ -153,6 +182,7 @@ def start_dask(num_workers, msg, logger, config=None):
 
             cluster = SGECluster()
         cluster.scale(num_workers)
+    client = None
     try:
         with Timing_Messager(
             f"Starting {cluster_type} dask cluster for {msg} with {num_workers} workers",
@@ -172,8 +202,7 @@ def start_dask(num_workers, msg, logger, config=None):
         )
         yield client
     finally:
-        client.shutdown()
-        client.close()
+        _close_dask_client(client, msg, logger)
 
 
 def setup_execution_directory(config_path, logger):

--- a/src/mesh_n_bone/util/dask_util.py
+++ b/src/mesh_n_bone/util/dask_util.py
@@ -501,6 +501,79 @@ try:
                 block_rois[index:] = []
         return block_rois
 
+    def count_blocks(roi, block_size_world):
+        """Number of blocks needed to tile *roi* with *block_size_world*.
+
+        Cheap, geometry-only — no I/O, no Roi-list materialization.
+
+        Parameters
+        ----------
+        roi : funlib.geometry.Roi
+            Region of interest.
+        block_size_world : sequence of int
+            Block extent in the same units as ``roi`` (world / nm).
+
+        Returns
+        -------
+        int
+            Number of blocks (product of ceil(shape / block_size)).
+        """
+        bs = tuple(block_size_world)
+        return int(
+            np.prod([np.ceil(roi.shape[i] / bs[i]) for i in range(len(bs))])
+        )
+
+    def block_from_index(
+        index,
+        roi_begin,
+        roi_end,
+        block_size_world,
+        padding=None,
+    ):
+        """Materialize a single block's ``DaskBlock`` from its sequential index.
+
+        Inverts the index-assignment order used by :func:`create_blocks`
+        (innermost loop is axis 0, outermost is axis 2). Workers call
+        this with just the index plus a small pickleable config — the
+        driver never has to build a list of all block objects.
+
+        Parameters
+        ----------
+        index : int
+            Sequential block index, ``0 <= index < count_blocks(...)``.
+        roi_begin, roi_end : sequence of int
+            ROI extent in world coordinates (same units as
+            *block_size_world*).
+        block_size_world : sequence of int
+            Block extent in world units.
+        padding : sequence of int or None
+            Symmetric padding to grow the block ROI by, matching the
+            ``padding`` argument of :func:`create_blocks`.
+
+        Returns
+        -------
+        DaskBlock
+            Block with ``index`` and ``roi`` populated.
+        """
+        from funlib.geometry import Coordinate
+        bs = tuple(block_size_world)
+        rb = tuple(roi_begin)
+        re = tuple(roi_end)
+        shape = tuple(re[i] - rb[i] for i in range(3))
+        n0 = int(np.ceil(shape[0] / bs[0]))
+        n1 = int(np.ceil(shape[1] / bs[1]))
+        # Match create_blocks: outer loop dim_2, then dim_1, then dim_0.
+        i2, rem = divmod(index, n0 * n1)
+        i1, i0 = divmod(rem, n0)
+        start = Coordinate(rb[0] + i0 * bs[0], rb[1] + i1 * bs[1], rb[2] + i2 * bs[2])
+        block_roi = Roi(start, Coordinate(bs))
+        if padding:
+            from funlib.geometry import Coordinate
+            # Coordinate.grow requires a Coordinate, not a tuple — wrap.
+            pad = padding if isinstance(padding, Coordinate) else Coordinate(padding)
+            block_roi = block_roi.grow(pad, pad)
+        return DaskBlock(index, block_roi)
+
 except ImportError:
     # funlib not available - block-based processing won't work
     # but multires pipeline doesn't need it

--- a/src/mesh_n_bone/util/dask_util.py
+++ b/src/mesh_n_bone/util/dask_util.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager, nullcontext
+import copy
 import os
 import dask
 from dask.distributed import Client, wait
@@ -214,6 +215,18 @@ def _load_dask_config():
         return yaml.load(f, Loader=SafeLoader)
 
 
+def set_jobqueue_processes(config, cluster_type, processes):
+    """Set worker processes in a jobqueue config, keeping one thread/process."""
+    processes = max(1, int(processes))
+    settings = config["jobqueue"][cluster_type]
+    settings["processes"] = processes
+    if "cores" in settings:
+        # dask-jobqueue derives threads per worker from cores/processes.
+        # Keep that ratio at one so a memory-heavy worker process does not
+        # execute multiple mesh assemblies concurrently.
+        settings["cores"] = processes
+
+
 def run_with_oom_retry(
     work_fn,
     num_workers,
@@ -221,6 +234,7 @@ def run_with_oom_retry(
     logger,
     max_retries=3,
     retry_on_oom=True,
+    config=None,
 ):
     """Run a dask phase with optional retry on worker out-of-memory crashes.
 
@@ -234,9 +248,8 @@ def run_with_oom_retry(
     symptom of a worker SIGKILL'd by the OS OOM-killer or LSF mem
     limit), we halve ``processes`` per slot in the in-memory dask
     config and halve *num_workers* to match — doubling the memory
-    available to each worker while keeping the LSF slot count
-    (and CPU budget) constant. Then we retry the phase, up to
-    *max_retries* times.
+    available to each worker while keeping one dask thread per process.
+    Then we retry the phase, up to *max_retries* times.
 
     Parameters
     ----------
@@ -253,20 +266,36 @@ def run_with_oom_retry(
     retry_on_oom : bool
         Set to ``False`` to skip the retry wrapper entirely (acts as a
         passthrough). Useful for synchronous (``num_workers==1``) runs.
+    config : dict, optional
+        Dask config to use instead of loading ``dask-config.yaml``. The
+        config is deep-copied before mutation so callers can reuse their
+        base config across phases.
     """
-    if not retry_on_oom or max_retries < 1 or num_workers <= 1:
-        return work_fn(num_workers, None)
+    if config is not None:
+        config = copy.deepcopy(config)
+
+    if not retry_on_oom or max_retries < 1:
+        return work_fn(num_workers, config)
 
     try:
         from distributed.scheduler import KilledWorker
     except ImportError:
-        return work_fn(num_workers, None)
+        return work_fn(num_workers, config)
 
-    config = _load_dask_config()
+    if config is None:
+        if num_workers <= 1:
+            return work_fn(num_workers, None)
+        config = _load_dask_config()
     cluster_type = next(iter(config.get("jobqueue", {})), None)
     if cluster_type not in ("lsf", "slurm", "sge"):
         # Local/in-process clusters don't have a processes/slot lever;
         # skip retry wrapping there.
+        return work_fn(num_workers, config)
+
+    starting_processes = int(
+        config["jobqueue"][cluster_type].get("processes", 1) or 1
+    )
+    if num_workers <= 1 and starting_processes <= 1:
         return work_fn(num_workers, config)
 
     workers = num_workers
@@ -298,7 +327,7 @@ def run_with_oom_retry(
             logger.warning(
                 "Phase '%s' worker OOM (retry %d/%d). Halving "
                 "processes/slot %d→%d and workers %d→%d to give each worker "
-                "more memory; LSF slot count and CPU budget unchanged. "
+                "more memory while keeping one dask thread per process. "
                 "To find the segment that crashed: grep "
                 "job-logs/LSFCluster-*.err for the last 'mesh_id=...' line "
                 "from the killed worker at %s.",
@@ -306,7 +335,7 @@ def run_with_oom_retry(
                 processes, new_processes, workers, new_workers,
                 last_worker or "(unknown address)",
             )
-            config["jobqueue"][cluster_type]["processes"] = new_processes
+            set_jobqueue_processes(config, cluster_type, new_processes)
             workers = new_workers
 
 

--- a/src/mesh_n_bone/util/image_data_interface.py
+++ b/src/mesh_n_bone/util/image_data_interface.py
@@ -25,6 +25,31 @@ from mesh_n_bone.util.precomputed_io import (
 logger = logging.getLogger(__name__)
 
 
+def _capped_tensorstore_context_spec():
+    """Tensorstore Context spec that limits internal thread pools.
+
+    Tensorstore defaults every concurrency resource (HTTP fetch pools,
+    data-copy / decompression pool, file I/O pool) to a high number,
+    typically N_CPU. In a dask-worker process — where dask itself
+    already runs us in a 1-thread-per-worker model — those default
+    pools combine with the dozens of worker processes stacked on a
+    single LSF host to produce thousands of runnable threads and
+    nodes-over-100%-load complaints from cluster admins. Cap each
+    pool to a small fixed limit so per-process thread count is bounded.
+    """
+    return {
+        # In-memory copying + decompression (e.g. gzip/blosc for zarr/n5).
+        "data_copy_concurrency": {"limit": 1},
+        # Local file I/O (irrelevant for remote sources but caps anyway).
+        "file_io_concurrency": {"limit": 1},
+        # GCS / S3 / generic HTTP fetch pools — allow 2 so a fetch can
+        # be in flight while the previous chunk is being decompressed.
+        "gcs_request_concurrency": {"limit": 2},
+        "s3_request_concurrency": {"limit": 2},
+        "http_request_concurrency": {"limit": 2},
+    }
+
+
 def _detect_zarr_driver(dataset_path):
     """Detect the tensorstore driver for *dataset_path* by content probing.
 
@@ -113,6 +138,7 @@ def open_ds_tensorstore(dataset_path, mode="r", filetype=None):
     spec = {
         "driver": filetype,
         "kvstore": kvstore,
+        "context": _capped_tensorstore_context_spec(),
     }
     if mode == "r":
         dataset_future = ts.open(spec, read=True, write=False)

--- a/src/mesh_n_bone/util/image_data_interface.py
+++ b/src/mesh_n_bone/util/image_data_interface.py
@@ -42,11 +42,12 @@ def _capped_tensorstore_context_spec():
         "data_copy_concurrency": {"limit": 1},
         # Local file I/O (irrelevant for remote sources but caps anyway).
         "file_io_concurrency": {"limit": 1},
-        # GCS / S3 / generic HTTP fetch pools — allow 2 so a fetch can
-        # be in flight while the previous chunk is being decompressed.
-        "gcs_request_concurrency": {"limit": 2},
-        "s3_request_concurrency": {"limit": 2},
-        "http_request_concurrency": {"limit": 2},
+        # Remote fetch pools. Keep these at one per worker process; Dask
+        # supplies the process-level parallelism, and large remote reads
+        # otherwise multiply into thousands of simultaneous requests.
+        "gcs_request_concurrency": {"limit": 1},
+        "s3_request_concurrency": {"limit": 1},
+        "http_request_concurrency": {"limit": 1},
     }
 
 
@@ -147,7 +148,7 @@ def open_ds_tensorstore(dataset_path, mode="r", filetype=None):
     return dataset_future.result()
 
 
-def read_with_retries(dataset, valid_slices, max_retries=10, timeout=5):
+def read_with_retries(dataset, valid_slices, max_retries=10, timeout=60):
     """Read from TensorStore with exponential backoff on timeout.
 
     Parameters
@@ -182,7 +183,7 @@ def read_with_retries(dataset, valid_slices, max_retries=10, timeout=5):
 
 
 def to_ndarray_tensorstore(dataset, roi, voxel_size, offset, swap_axes=False,
-                           fill_value=0, max_retries=10, timeout=5):
+                           fill_value=0, max_retries=10, timeout=60):
     """Read a region of a TensorStore dataset as a numpy array.
 
     Handles padding when the ROI extends beyond dataset bounds.

--- a/src/mesh_n_bone/util/image_data_interface.py
+++ b/src/mesh_n_bone/util/image_data_interface.py
@@ -25,6 +25,41 @@ from mesh_n_bone.util.precomputed_io import (
 logger = logging.getLogger(__name__)
 
 
+def _read_shape_from_slices(valid_slices):
+    """Return the array shape implied by TensorStore slices."""
+    return tuple(max(0, int(s.stop) - int(s.start)) for s in valid_slices)
+
+
+def _read_size_mib(dataset, valid_slices):
+    """Estimate uncompressed read size in MiB from slices and dtype."""
+    shape = _read_shape_from_slices(valid_slices)
+    try:
+        itemsize = np.dtype(dataset.dtype.numpy_dtype).itemsize
+    except (AttributeError, TypeError):
+        itemsize = np.dtype(dataset.dtype).itemsize
+    return (float(np.prod(shape)) * itemsize) / 2**20
+
+
+def _is_remote_dataset_path(source_path):
+    """Return True if a source path points at remote object storage/HTTP."""
+    if source_path is None:
+        return False
+    return _is_remote_url(_strip_precomputed_prefix(source_path))
+
+
+def _default_read_timeout_seconds(dataset, valid_slices, source_path=None):
+    """Choose a TensorStore read timeout from source locality and read size.
+
+    Small reads keep the old 5 second timeout. Large remote reads get more
+    time so a slow object-store response does not immediately create retry
+    pressure across hundreds of Dask worker processes.
+    """
+    size_mib = _read_size_mib(dataset, valid_slices)
+    if _is_remote_dataset_path(source_path):
+        return min(120.0, max(5.0, size_mib / 16.0))
+    return min(30.0, max(5.0, size_mib / 256.0))
+
+
 def _capped_tensorstore_context_spec():
     """Tensorstore Context spec that limits internal thread pools.
 
@@ -148,7 +183,9 @@ def open_ds_tensorstore(dataset_path, mode="r", filetype=None):
     return dataset_future.result()
 
 
-def read_with_retries(dataset, valid_slices, max_retries=10, timeout=60):
+def read_with_retries(
+    dataset, valid_slices, max_retries=10, timeout=None, source_path=None,
+):
     """Read from TensorStore with exponential backoff on timeout.
 
     Parameters
@@ -159,21 +196,29 @@ def read_with_retries(dataset, valid_slices, max_retries=10, timeout=60):
         Slices to read.
     max_retries : int
         Maximum retry attempts.
-    timeout : float
-        Base timeout in seconds per attempt.
+    timeout : float or None
+        Base timeout in seconds per attempt. ``None`` chooses a default
+        from read size and whether *source_path* is local or remote.
+    source_path : str, optional
+        Dataset path used only to distinguish local reads from remote reads.
 
     Returns
     -------
     numpy.ndarray
         Data read from the dataset.
     """
+    if timeout is None:
+        timeout = _default_read_timeout_seconds(dataset, valid_slices, source_path)
+
     for attempt in range(1, max_retries + 1):
+        attempt_timeout = timeout * attempt
         try:
-            return dataset[valid_slices].read().result(timeout=timeout * attempt)
+            return dataset[valid_slices].read().result(timeout=attempt_timeout)
         except TimeoutError as e:
             logger.error(
                 f"[Attempt {attempt}/{max_retries}] "
-                f"Timeout reading slices={valid_slices!r}: {e}"
+                f"Timeout after {attempt_timeout:.1f}s "
+                f"reading slices={valid_slices!r}: {e}"
             )
             if attempt == max_retries:
                 raise
@@ -183,7 +228,8 @@ def read_with_retries(dataset, valid_slices, max_retries=10, timeout=60):
 
 
 def to_ndarray_tensorstore(dataset, roi, voxel_size, offset, swap_axes=False,
-                           fill_value=0, max_retries=10, timeout=60):
+                           fill_value=0, max_retries=10, timeout=None,
+                           source_path=None):
     """Read a region of a TensorStore dataset as a numpy array.
 
     Handles padding when the ROI extends beyond dataset bounds.
@@ -205,8 +251,11 @@ def to_ndarray_tensorstore(dataset, roi, voxel_size, offset, swap_axes=False,
         Padding value for out-of-bounds regions.
     max_retries : int
         Maximum retry attempts for reading.
-    timeout : float
-        Base timeout in seconds per read attempt.
+    timeout : float or None
+        Base timeout in seconds per read attempt. ``None`` chooses a default
+        from read size and whether *source_path* is local or remote.
+    source_path : str, optional
+        Dataset path used only to distinguish local reads from remote reads.
 
     Returns
     -------
@@ -272,7 +321,9 @@ def to_ndarray_tensorstore(dataset, roi, voxel_size, offset, swap_axes=False,
         )
         return np.full(output_shape, fill_value, dtype=dataset.dtype.numpy_dtype)
 
-    data = read_with_retries(dataset, valid_slices, max_retries, timeout)
+    data = read_with_retries(
+        dataset, valid_slices, max_retries, timeout, source_path=source_path,
+    )
 
     if np.any(np.array(pad_width)):
         data = np.pad(

--- a/src/mesh_n_bone/util/precomputed_io.py
+++ b/src/mesh_n_bone/util/precomputed_io.py
@@ -133,6 +133,9 @@ def open_precomputed_tensorstore(path, scale_index=None):
     converts it to ZYX.
     """
     import tensorstore as ts
+    from mesh_n_bone.util.image_data_interface import (
+        _capped_tensorstore_context_spec,
+    )
 
     kvstore, base_path, info, default_scale = parse_precomputed_path(path)
     if scale_index is None:
@@ -145,6 +148,7 @@ def open_precomputed_tensorstore(path, scale_index=None):
         "driver": "neuroglancer_precomputed",
         "kvstore": kvstore_with_path,
         "scale_index": int(scale_index),
+        "context": _capped_tensorstore_context_spec(),
     }
     ds = ts.open(spec, read=True, write=False).result()
 

--- a/tests/test_dask_retry.py
+++ b/tests/test_dask_retry.py
@@ -121,7 +121,11 @@ class TestRunWithOomRetry:
     ):
         attempts = []
         def work(workers, cfg):
-            attempts.append((workers, cfg["jobqueue"]["lsf"]["processes"]))
+            attempts.append((
+                workers,
+                cfg["jobqueue"]["lsf"]["processes"],
+                cfg["jobqueue"]["lsf"]["cores"],
+            ))
             if len(attempts) < 3:
                 raise _FakeKilledWorker(
                     "Attempted to run task on N workers",
@@ -138,11 +142,38 @@ class TestRunWithOomRetry:
         # First try: 576 workers, processes=12
         # Retry 1:   288, 6
         # Retry 2:   144, 3
-        assert attempts == [(576, 12), (288, 6), (144, 3)]
+        assert attempts == [(576, 12, 12), (288, 6, 6), (144, 3, 3)]
         # Each retry produces a clearly-flagged warning
         warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
         assert any("retry 1/3" in m for m in warnings)
         assert any("retry 2/3" in m for m in warnings)
+
+    def test_uses_supplied_config(self, fake_distributed):
+        calls = []
+        cfg = {
+            "jobqueue": {
+                "lsf": {
+                    "ncpus": 12,
+                    "processes": 6,
+                    "cores": 6,
+                    "memory": "180GB",
+                }
+            }
+        }
+
+        def work(workers, cfg):
+            calls.append((workers, cfg["jobqueue"]["lsf"]["processes"]))
+            return "ok"
+
+        result = dask_util.run_with_oom_retry(
+            work, num_workers=12, phase_name="assemble",
+            logger=logging.getLogger("test"),
+            max_retries=3,
+            config=cfg,
+        )
+        assert result == "ok"
+        assert calls == [(12, 6)]
+        assert cfg["jobqueue"]["lsf"]["processes"] == 6
 
     def test_gives_up_after_max_retries(
         self, fake_distributed, fake_dask_config,

--- a/tests/test_dask_retry.py
+++ b/tests/test_dask_retry.py
@@ -68,6 +68,26 @@ class TestEffectiveNumWorkers:
         assert any("5" in r.message for r in caplog.records)
 
 
+class TestGuesstimateNPartitions:
+    def test_avoids_dask_range_huge_final_partition(self):
+        elements = 217620
+        workers = 576
+
+        direct_partitions = min(elements, workers * 10)
+        direct_size = elements // direct_partitions
+        direct_last_size = elements - (direct_partitions - 1) * direct_size
+        assert direct_last_size == 4537
+
+        partitions = dask_util.guesstimate_npartitions(elements, workers)
+        size = elements // partitions
+        last_size = elements - (partitions - 1) * size
+
+        assert partitions == 5881
+        assert size == 37
+        assert last_size == 60
+        assert last_size <= size * 2
+
+
 class TestRunWithOomRetry:
     def test_passthrough_when_disabled(self):
         calls = []

--- a/tests/test_dask_retry.py
+++ b/tests/test_dask_retry.py
@@ -108,6 +108,31 @@ class TestSetJobqueueProcesses:
         assert settings["ncpus"] == 12
 
 
+class TestCloseDaskClient:
+    def test_shutdown_assertion_is_warning_not_failure(self, caplog):
+        class Client:
+            def __init__(self):
+                self.closed = False
+
+            def shutdown(self):
+                raise AssertionError("Status.running")
+
+            def close(self):
+                self.closed = True
+
+        client = Client()
+
+        with caplog.at_level(logging.WARNING, logger="test"):
+            dask_util._close_dask_client(
+                client,
+                "assemble meshes",
+                logging.getLogger("test"),
+            )
+
+        assert client.closed
+        assert any("Dask shutdown failed" in r.message for r in caplog.records)
+
+
 class TestRunWithOomRetry:
     def test_passthrough_when_disabled(self):
         calls = []

--- a/tests/test_dask_retry.py
+++ b/tests/test_dask_retry.py
@@ -88,6 +88,26 @@ class TestGuesstimateNPartitions:
         assert last_size <= size * 2
 
 
+class TestSetJobqueueProcesses:
+    def test_preserves_lsf_scheduler_cpu_request(self):
+        cfg = {
+            "jobqueue": {
+                "lsf": {
+                    "ncpus": 12,
+                    "processes": 12,
+                    "cores": 12,
+                }
+            }
+        }
+
+        dask_util.set_jobqueue_processes(cfg, "lsf", 5)
+
+        settings = cfg["jobqueue"]["lsf"]
+        assert settings["processes"] == 5
+        assert settings["cores"] == 5
+        assert settings["ncpus"] == 12
+
+
 class TestRunWithOomRetry:
     def test_passthrough_when_disabled(self):
         calls = []
@@ -125,6 +145,7 @@ class TestRunWithOomRetry:
                 workers,
                 cfg["jobqueue"]["lsf"]["processes"],
                 cfg["jobqueue"]["lsf"]["cores"],
+                cfg["jobqueue"]["lsf"]["ncpus"],
             ))
             if len(attempts) < 3:
                 raise _FakeKilledWorker(
@@ -142,7 +163,11 @@ class TestRunWithOomRetry:
         # First try: 576 workers, processes=12
         # Retry 1:   288, 6
         # Retry 2:   144, 3
-        assert attempts == [(576, 12, 12), (288, 6, 6), (144, 3, 3)]
+        assert attempts == [
+            (576, 12, 12, 12),
+            (288, 6, 6, 12),
+            (144, 3, 3, 12),
+        ]
         # Each retry produces a clearly-flagged warning
         warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
         assert any("retry 1/3" in m for m in warnings)

--- a/tests/test_integration_multires.py
+++ b/tests/test_integration_multires.py
@@ -4,6 +4,7 @@ Tests the full workflow: mesh → decomposition → Draco compression → neurog
 """
 
 import json
+import logging
 import numpy as np
 import os
 import pytest
@@ -517,7 +518,7 @@ class TestLodTruncation:
             "The last valid LOD may be getting dropped."
         )
 
-    def test_lod_truncation_on_non_decreasing_faces(self, tmp_output_dir):
+    def test_lod_truncation_on_non_decreasing_faces(self, tmp_output_dir, caplog):
         """If a higher LOD has >= faces than the previous, truncate there."""
         output_path = os.path.join(tmp_output_dir, "truncation_test")
         mesh_lods = os.path.join(output_path, "mesh_lods")
@@ -534,14 +535,15 @@ class TestLodTruncation:
         os.makedirs(s1_dir)
         mesh.export(os.path.join(s1_dir, "1.ply"))
 
-        generate_neuroglancer_multires_mesh(
-            id=1,
-            num_subtask_workers=1,
-            output_path=output_path,
-            lods=[0, 1],
-            original_ext=".ply",
-            lod_0_box_size=None,
-        )
+        with caplog.at_level(logging.INFO, logger="mesh_n_bone.multires.multires"):
+            generate_neuroglancer_multires_mesh(
+                id=1,
+                num_subtask_workers=1,
+                output_path=output_path,
+                lods=[0, 1],
+                original_ext=".ply",
+                lod_0_box_size=None,
+            )
 
         index_file = os.path.join(output_path, "multires", "1.index")
         with open(index_file, "rb") as f:
@@ -549,6 +551,43 @@ class TestLodTruncation:
         num_lods = struct.unpack("<I", data[24:28])[0]
         # LOD 1 has same face count as LOD 0, so it should be truncated
         assert num_lods == 1
+        assert any(
+            "dropping LOD 1 and later because it has" in r.message
+            and "not fewer than LOD 0" in r.message
+            for r in caplog.records
+        )
+
+    def test_lod_truncation_on_missing_candidate_mesh(self, tmp_output_dir, caplog):
+        """If a requested higher LOD mesh is missing, log why it was dropped."""
+        output_path = os.path.join(tmp_output_dir, "missing_lod_test")
+        mesh_lods = os.path.join(output_path, "mesh_lods")
+
+        mesh = trimesh.creation.icosphere(subdivisions=3, radius=50.0)
+        mesh.vertices += 100
+        s0_dir = os.path.join(mesh_lods, "s0")
+        os.makedirs(s0_dir)
+        mesh.export(os.path.join(s0_dir, "1.ply"))
+
+        with caplog.at_level(logging.INFO, logger="mesh_n_bone.multires.multires"):
+            generate_neuroglancer_multires_mesh(
+                id=1,
+                num_subtask_workers=1,
+                output_path=output_path,
+                lods=[0, 1],
+                original_ext=".ply",
+                lod_0_box_size=None,
+            )
+
+        index_file = os.path.join(output_path, "multires", "1.index")
+        with open(index_file, "rb") as f:
+            data = f.read()
+        num_lods = struct.unpack("<I", data[24:28])[0]
+        assert num_lods == 1
+        assert any(
+            "dropping LOD 1 and later because" in r.message
+            and "could not be loaded or has no faces" in r.message
+            for r in caplog.records
+        )
 
     def test_listed_grid_stays_tight_with_many_lods(self, tmp_output_dir):
         """Listed-fragment grid tracks union mesh extent, not ``octree_unit``.
@@ -625,7 +664,7 @@ class TestLodTruncation:
             "mesh extent, not octree_unit."
         )
 
-    def test_auto_lods_truncated_to_bound_grid_padding(self, tmp_output_dir):
+    def test_auto_lods_truncated_to_bound_grid_padding(self, tmp_output_dir, caplog):
         """Auto chunking treats requested LODs as an upper bound.
 
         Small meshes should not be forced into a deep octree whose padded
@@ -655,14 +694,15 @@ class TestLodTruncation:
                 v, f, _ = simplifier.getMesh()
                 trimesh.Trimesh(v, f).export(os.path.join(lod_dir, "1.ply"))
 
-        generate_neuroglancer_multires_mesh(
-            id=1,
-            num_subtask_workers=1,
-            output_path=output_path,
-            lods=[0, 1, 2, 3],
-            original_ext=".ply",
-            lod_0_box_size=None,
-        )
+        with caplog.at_level(logging.INFO, logger="mesh_n_bone.multires.multires"):
+            generate_neuroglancer_multires_mesh(
+                id=1,
+                num_subtask_workers=1,
+                output_path=output_path,
+                lods=[0, 1, 2, 3],
+                original_ext=".ply",
+                lod_0_box_size=None,
+            )
 
         index_file = os.path.join(output_path, "multires", "1.index")
         with open(index_file, "rb") as f:
@@ -671,6 +711,12 @@ class TestLodTruncation:
         assert num_lods == 2, (
             "Default auto chunking should drop excessive LODs for this "
             f"small mesh; got {num_lods} LODs."
+        )
+        assert any(
+            "Reducing segment 1 from 4 to 2 LODs for auto chunking" in r.message
+            and "auto_box_size=" in r.message
+            and "lod0_grid=" in r.message
+            for r in caplog.records
         )
 
     def test_three_lods_all_valid(self, tmp_output_dir):

--- a/tests/test_integration_multiscale.py
+++ b/tests/test_integration_multiscale.py
@@ -11,13 +11,15 @@ import pytest
 import struct
 
 
-# Common kwargs for all tests
+# Common kwargs for all tests. These tests inspect per-segment unsharded
+# files (`.index`, `.ply`), so opt out of the default sharded packing.
 _BASE_KWARGS = dict(
     num_workers=1,
     do_simplification=False,
     check_mesh_validity=False,
     do_analysis=False,
     n_smoothing_iter=0,
+    sharded=False,
 )
 
 

--- a/tests/test_meshify.py
+++ b/tests/test_meshify.py
@@ -356,6 +356,78 @@ class TestStagedReductions:
         with pytest.raises(AssertionError):
             staged_reductions(0.99, 0.3, 0.3)
 
+    def test_assembly_uses_second_stage_reduction(self, tmp_output_dir, monkeypatch):
+        from cloudvolume.mesh import Mesh as CloudVolumeMesh
+        from mesh_n_bone.meshify.meshify import Meshify, staged_reductions
+
+        block_dir = os.path.join(tmp_output_dir, "blocks", "1")
+        output_dir = os.path.join(tmp_output_dir, "out")
+        os.makedirs(block_dir)
+        os.makedirs(os.path.join(output_dir, "meshes"))
+
+        vertices = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+            ],
+            dtype=np.float32,
+        )
+        faces = np.array(
+            [
+                [0, 1, 2],
+                [0, 1, 3],
+                [0, 2, 3],
+                [1, 2, 3],
+            ],
+            dtype=np.uint32,
+        )
+        mesh = CloudVolumeMesh(vertices, faces, normals=None)
+        with open(os.path.join(block_dir, "block_0.ply"), "wb") as f:
+            f.write(mesh.to_ply())
+
+        reductions = []
+
+        def fake_simplify_and_smooth_mesh(input_mesh, target_reduction, *args, **kwargs):
+            reductions.append(target_reduction)
+            return trimesh.Trimesh(
+                vertices=input_mesh.vertices,
+                faces=input_mesh.faces,
+                process=False,
+            )
+
+        monkeypatch.setattr(
+            Meshify,
+            "simplify_and_smooth_mesh",
+            staticmethod(fake_simplify_and_smooth_mesh),
+        )
+
+        meshify = object.__new__(Meshify)
+        meshify.dirname = os.path.join(tmp_output_dir, "blocks")
+        meshify.output_directory = output_dir
+        meshify.max_num_blocks = 100
+        meshify.check_mesh_validity = False
+        meshify.has_custom_roi = False
+        meshify.remove_smallest_components = False
+        meshify.use_fixed_edge_simplification = True
+        meshify.do_simplification = True
+        meshify.target_reduction = 0.933
+        meshify.stage_1_reduction_fraction = 0.25
+        meshify.stage_2_reduction_fraction = 0.75
+        meshify.n_smoothing_iter = 0
+        meshify.default_aggressiveness = 0.3
+        meshify.smooth_before_simplify = True
+        meshify.true_voxel_size = np.array([1, 1, 1])
+        meshify.output_voxel_size_funlib = np.array([1, 1, 1])
+        meshify.do_legacy_neuroglancer = False
+        meshify.do_singleres_multires_neuroglancer = False
+
+        meshify._assemble_mesh("1")
+
+        _, expected_stage_2 = staged_reductions(0.933, 0.25, 0.75)
+        assert reductions == [expected_stage_2]
+
 
 class TestRepairMeshPymeshlab:
     def test_repair_simple_mesh(self, tiny_cube_mesh):

--- a/tests/test_meshify.py
+++ b/tests/test_meshify.py
@@ -85,6 +85,88 @@ class TestTargetIdsWorker:
             assert remap[old] == new
 
 
+class TestEstimateBlockTargetMb:
+    """`_estimate_block_target_mb_from_dask_config` reads dask-config.yaml
+    and returns a per-block memory budget derived from per-worker RAM."""
+
+    def test_fallback_when_no_config(self, tmp_output_dir):
+        from mesh_n_bone.meshify.meshify import _estimate_block_target_mb_from_dask_config
+        missing = os.path.join(tmp_output_dir, "missing-dask-config.yaml")
+        assert _estimate_block_target_mb_from_dask_config(missing, fallback_mb=128) == 128
+
+    def test_real_lsf_config(self, tmp_output_dir):
+        from mesh_n_bone.meshify.meshify import _estimate_block_target_mb_from_dask_config
+        path = os.path.join(tmp_output_dir, "dask-config.yaml")
+        with open(path, "w") as f:
+            f.write("jobqueue:\n  lsf:\n    memory: 180GB\n    processes: 12\n")
+        # 180 GB / 12 = 15 GB per worker; with amplification=8 -> 1875 MB,
+        # capped to 1024 MB.
+        result = _estimate_block_target_mb_from_dask_config(path, cap_mb=1024)
+        assert result == 1024
+
+    def test_small_worker_keeps_fallback(self, tmp_output_dir):
+        from mesh_n_bone.meshify.meshify import _estimate_block_target_mb_from_dask_config
+        path = os.path.join(tmp_output_dir, "dask-config.yaml")
+        # 1 GB worker memory / 8 = 125 MB, smaller than the floor.
+        with open(path, "w") as f:
+            f.write("jobqueue:\n  local:\n    memory: 1GB\n    processes: 1\n")
+        # Floored at fallback_mb to keep block size sane.
+        result = _estimate_block_target_mb_from_dask_config(
+            path, fallback_mb=128, cap_mb=1024
+        )
+        assert result == 128
+
+    def test_malformed_config_falls_back(self, tmp_output_dir):
+        from mesh_n_bone.meshify.meshify import _estimate_block_target_mb_from_dask_config
+        path = os.path.join(tmp_output_dir, "dask-config.yaml")
+        with open(path, "w") as f:
+            f.write("not-jobqueue:\n  foo: bar\n")
+        assert _estimate_block_target_mb_from_dask_config(path, fallback_mb=128) == 128
+
+
+class TestBlockFromIndex:
+    """`block_from_index` should produce the same DaskBlocks as
+    `create_blocks` would, indexed by integer."""
+
+    def test_index_parity_with_eager_create_blocks(self):
+        from mesh_n_bone.util.dask_util import (
+            block_from_index, count_blocks, create_blocks,
+        )
+        from funlib.geometry import Coordinate, Roi
+        from types import SimpleNamespace
+
+        roi = Roi((0, 0, 0), (96, 64, 128))
+        block_size_world = Coordinate(32, 32, 32)
+        ds = SimpleNamespace(
+            chunk_shape=block_size_world,
+            voxel_size=Coordinate(1, 1, 1),
+        )
+        eager = create_blocks(roi, ds)
+        n_eager = len(eager)
+        n_lazy = count_blocks(roi, block_size_world)
+        assert n_eager == n_lazy
+        for i in range(n_eager):
+            lazy = block_from_index(
+                i, roi.get_begin(), roi.get_end(), block_size_world,
+            )
+            assert lazy.index == eager[i].index == i
+            assert tuple(lazy.roi.get_begin()) == tuple(eager[i].roi.get_begin()), (
+                f"index {i}: {lazy.roi.get_begin()} != {eager[i].roi.get_begin()}"
+            )
+            assert tuple(lazy.roi.get_end()) == tuple(eager[i].roi.get_end())
+
+    def test_padding_round_trip(self):
+        from mesh_n_bone.util.dask_util import block_from_index
+        from funlib.geometry import Coordinate
+
+        b = block_from_index(
+            0, (0, 0, 0), (32, 32, 32), (32, 32, 32), padding=Coordinate(4, 4, 4)
+        )
+        # padding=(4,4,4) grows the (0,0,0)+(32,32,32) block by 4 on each side
+        assert tuple(b.roi.get_begin()) == (-4, -4, -4)
+        assert tuple(b.roi.get_shape()) == (40, 40, 40)
+
+
 class TestStagedReductions:
     def test_staged_reductions_sum(self):
         from mesh_n_bone.meshify.meshify import staged_reductions

--- a/tests/test_meshify.py
+++ b/tests/test_meshify.py
@@ -236,7 +236,59 @@ class TestAssemblyMemoryPlanning:
         assert large_wave.workers == 5
         assert large_wave.config["jobqueue"]["lsf"]["processes"] == 5
         assert large_wave.config["jobqueue"]["lsf"]["cores"] == 5
+        assert large_wave.config["jobqueue"]["lsf"]["ncpus"] == 12
         assert cfg["jobqueue"]["lsf"]["processes"] == 12
+        assert cfg["jobqueue"]["lsf"]["ncpus"] == 12
+
+
+class TestTensorStoreReadTimeouts:
+    class _FakeDType:
+        numpy_dtype = np.dtype("uint64")
+
+    class _FakeDataset:
+        dtype = _FakeDType()
+
+    def _slices_for_mib(self, mib):
+        voxels = int(mib * 2**20 / np.dtype("uint64").itemsize)
+        return (slice(0, voxels),)
+
+    def test_small_reads_keep_old_five_second_timeout(self):
+        from mesh_n_bone.util.image_data_interface import (
+            _default_read_timeout_seconds,
+        )
+
+        slices = self._slices_for_mib(67)
+        assert _default_read_timeout_seconds(
+            self._FakeDataset(), slices, "/nrs/local.zarr",
+        ) == 5.0
+        assert _default_read_timeout_seconds(
+            self._FakeDataset(), slices, "gs://bucket/volume",
+        ) == 5.0
+
+    def test_remote_timeout_scales_with_read_size(self):
+        from mesh_n_bone.util.image_data_interface import (
+            _default_read_timeout_seconds,
+        )
+
+        slices = self._slices_for_mib(512)
+        assert _default_read_timeout_seconds(
+            self._FakeDataset(), slices, "precomputed://gs://bucket/volume",
+        ) == 32.0
+
+    def test_local_timeout_scales_more_slowly_and_caps(self):
+        from mesh_n_bone.util.image_data_interface import (
+            _default_read_timeout_seconds,
+        )
+
+        slices = self._slices_for_mib(4096)
+        assert _default_read_timeout_seconds(
+            self._FakeDataset(), slices, "/nrs/local.zarr",
+        ) == 16.0
+
+        huge_slices = self._slices_for_mib(16384)
+        assert _default_read_timeout_seconds(
+            self._FakeDataset(), huge_slices, "/nrs/local.zarr",
+        ) == 30.0
 
 
 class TestBlockFromIndex:

--- a/tests/test_meshify.py
+++ b/tests/test_meshify.py
@@ -99,25 +99,25 @@ class TestEstimateBlockTargetMb:
         path = os.path.join(tmp_output_dir, "dask-config.yaml")
         with open(path, "w") as f:
             f.write("jobqueue:\n  lsf:\n    memory: 180GB\n    processes: 12\n")
-        # 180 GB / 12 = 15 GB per worker; amplification=16 -> ~937.5 MB.
+        # 180 GB / 12 = 15 GB per worker; amplification=6 -> ~2500 MB.
         result = _estimate_block_target_mb_from_dask_config(path)
-        assert 900 < result < 1000
+        assert 2400 < result < 2600
 
     def test_huge_worker_is_unbounded(self, tmp_output_dir):
         from mesh_n_bone.meshify.meshify import _estimate_block_target_mb_from_dask_config
         path = os.path.join(tmp_output_dir, "dask-config.yaml")
-        # 60 GB worker (no cap_mb anymore) -> ~3750 MB.
+        # 60 GB worker, no ceiling -> ~10000 MB.
         with open(path, "w") as f:
             f.write("jobqueue:\n  local:\n    memory: 60GB\n    processes: 1\n")
         result = _estimate_block_target_mb_from_dask_config(path)
-        assert 3500 < result < 4000
+        assert 9000 < result < 11000
 
     def test_small_worker_keeps_fallback(self, tmp_output_dir):
         from mesh_n_bone.meshify.meshify import _estimate_block_target_mb_from_dask_config
         path = os.path.join(tmp_output_dir, "dask-config.yaml")
-        # 1 GB worker memory / 16 = 62.5 MB, smaller than the floor.
+        # 256 MB worker / 6 ~= 43 MB, smaller than the floor.
         with open(path, "w") as f:
-            f.write("jobqueue:\n  local:\n    memory: 1GB\n    processes: 1\n")
+            f.write("jobqueue:\n  local:\n    memory: 256MB\n    processes: 1\n")
         result = _estimate_block_target_mb_from_dask_config(path, fallback_mb=128)
         assert result == 128
 

--- a/tests/test_meshify.py
+++ b/tests/test_meshify.py
@@ -99,21 +99,26 @@ class TestEstimateBlockTargetMb:
         path = os.path.join(tmp_output_dir, "dask-config.yaml")
         with open(path, "w") as f:
             f.write("jobqueue:\n  lsf:\n    memory: 180GB\n    processes: 12\n")
-        # 180 GB / 12 = 15 GB per worker; with amplification=8 -> 1875 MB,
-        # capped to 1024 MB.
-        result = _estimate_block_target_mb_from_dask_config(path, cap_mb=1024)
-        assert result == 1024
+        # 180 GB / 12 = 15 GB per worker; amplification=16 -> ~937.5 MB.
+        result = _estimate_block_target_mb_from_dask_config(path)
+        assert 900 < result < 1000
+
+    def test_huge_worker_is_unbounded(self, tmp_output_dir):
+        from mesh_n_bone.meshify.meshify import _estimate_block_target_mb_from_dask_config
+        path = os.path.join(tmp_output_dir, "dask-config.yaml")
+        # 60 GB worker (no cap_mb anymore) -> ~3750 MB.
+        with open(path, "w") as f:
+            f.write("jobqueue:\n  local:\n    memory: 60GB\n    processes: 1\n")
+        result = _estimate_block_target_mb_from_dask_config(path)
+        assert 3500 < result < 4000
 
     def test_small_worker_keeps_fallback(self, tmp_output_dir):
         from mesh_n_bone.meshify.meshify import _estimate_block_target_mb_from_dask_config
         path = os.path.join(tmp_output_dir, "dask-config.yaml")
-        # 1 GB worker memory / 8 = 125 MB, smaller than the floor.
+        # 1 GB worker memory / 16 = 62.5 MB, smaller than the floor.
         with open(path, "w") as f:
             f.write("jobqueue:\n  local:\n    memory: 1GB\n    processes: 1\n")
-        # Floored at fallback_mb to keep block size sane.
-        result = _estimate_block_target_mb_from_dask_config(
-            path, fallback_mb=128, cap_mb=1024
-        )
+        result = _estimate_block_target_mb_from_dask_config(path, fallback_mb=128)
         assert result == 128
 
     def test_malformed_config_falls_back(self, tmp_output_dir):

--- a/tests/test_meshify.py
+++ b/tests/test_meshify.py
@@ -242,10 +242,10 @@ class TestAssemblyMemoryPlanning:
 
 
 class TestTensorStoreReadTimeouts:
-    class _FakeDType:
-        numpy_dtype = np.dtype("uint64")
-
     class _FakeDataset:
+        class _FakeDType:
+            numpy_dtype = np.dtype("uint64")
+
         dtype = _FakeDType()
 
     def _slices_for_mib(self, mib):

--- a/tests/test_meshify.py
+++ b/tests/test_meshify.py
@@ -129,6 +129,116 @@ class TestEstimateBlockTargetMb:
         assert _estimate_block_target_mb_from_dask_config(path, fallback_mb=128) == 128
 
 
+class TestAssemblyMemoryPlanning:
+    def _write_binary_ply(self, path, vertices, faces):
+        header = (
+            "ply\n"
+            "format binary_little_endian 1.0\n"
+            f"element vertex {vertices}\n"
+            "property float x\n"
+            "property float y\n"
+            "property float z\n"
+            f"element face {faces}\n"
+            "property list int int vertex_indices\n"
+            "end_header\n"
+        ).encode("ascii")
+        body = b"\0" * (vertices * 3 * 4 + faces * 4 * 4)
+        with open(path, "wb") as f:
+            f.write(header + body)
+
+    def test_scans_ply_headers_for_mesh_estimates(self, tmp_output_dir):
+        from mesh_n_bone.meshify.meshify import _scan_assembly_mesh_estimates
+
+        mesh_dir = os.path.join(tmp_output_dir, "tmp_chunked", "42")
+        os.makedirs(mesh_dir)
+        self._write_binary_ply(os.path.join(mesh_dir, "block_0.ply"), 10, 20)
+        self._write_binary_ply(os.path.join(mesh_dir, "block_1.ply"), 2, 4)
+
+        estimates = _scan_assembly_mesh_estimates(
+            os.path.join(tmp_output_dir, "tmp_chunked"),
+            amplification=16,
+        )
+        assert len(estimates) == 1
+        estimate = estimates[0]
+        assert estimate.mesh_id == "42"
+        assert estimate.num_files == 2
+        assert estimate.vertex_count == 12
+        assert estimate.face_count == 24
+        assert estimate.raw_mesh_bytes == 12 * 3 * 8 + 24 * 3 * 4
+        assert estimate.estimated_peak_bytes > estimate.raw_mesh_bytes
+
+    def test_balanced_batches_leave_giant_mesh_alone(self):
+        from mesh_n_bone.meshify.meshify import (
+            AssemblyMeshEstimate,
+            _balanced_assembly_batches,
+        )
+
+        estimates = [
+            AssemblyMeshEstimate("giant", 1, 1000, 0, 0, 0, 1000),
+            *[
+                AssemblyMeshEstimate(f"small-{i}", 1, 1, 0, 0, 0, 1)
+                for i in range(20)
+            ],
+        ]
+        batches = _balanced_assembly_batches(estimates, max_batches=4)
+        giant_batches = [batch for batch in batches if "giant" in batch]
+        assert giant_batches == [["giant"]]
+        assert sum(len(batch) for batch in batches) == len(estimates)
+
+    def test_assembly_amplification_constants_cover_heavy_paths(self):
+        from mesh_n_bone.meshify.meshify import _assembly_memory_amplification
+
+        assert _assembly_memory_amplification(
+            do_simplification=True,
+            smooth_before_simplify=False,
+            check_mesh_validity=False,
+            has_custom_roi=False,
+        ) == 24
+        assert _assembly_memory_amplification(
+            do_simplification=True,
+            smooth_before_simplify=True,
+            check_mesh_validity=True,
+            has_custom_roi=False,
+        ) == 36
+        assert _assembly_memory_amplification(
+            do_simplification=False,
+            smooth_before_simplify=False,
+            check_mesh_validity=False,
+            has_custom_roi=False,
+        ) == 20
+
+    def test_plan_assembly_waves_lowers_processes_for_large_mesh(self):
+        from mesh_n_bone.meshify.meshify import (
+            AssemblyMeshEstimate,
+            _plan_assembly_waves,
+        )
+
+        cfg = {
+            "jobqueue": {
+                "lsf": {
+                    "ncpus": 12,
+                    "processes": 12,
+                    "cores": 12,
+                    "memory": "180GB",
+                }
+            }
+        }
+        gib = 2 ** 30
+        estimates = [
+            AssemblyMeshEstimate("large", 1, 100, 0, 0, 0, 20 * gib),
+            AssemblyMeshEstimate("small", 1, 1, 0, 0, 0, 1 * gib),
+        ]
+
+        waves = _plan_assembly_waves(estimates, requested_workers=576, config=cfg)
+        assert [wave.processes for wave in waves] == [5, 12]
+        large_wave = waves[0]
+        assert large_wave.batches == [["large"]]
+        assert large_wave.workers == 5
+        assert large_wave.config["jobqueue"]["lsf"]["processes"] == 5
+        assert large_wave.config["jobqueue"]["lsf"]["cores"] == 5
+        assert cfg["jobqueue"]["lsf"]["processes"] == 12
+
+
 class TestBlockFromIndex:
     """`block_from_index` should produce the same DaskBlocks as
     `create_blocks` would, indexed by integer."""

--- a/tests/test_meshify.py
+++ b/tests/test_meshify.py
@@ -356,6 +356,31 @@ class TestStagedReductions:
         with pytest.raises(AssertionError):
             staged_reductions(0.99, 0.3, 0.3)
 
+    def test_chunk_reduction_zero_when_fixed_edge_simplification_disabled(self):
+        from mesh_n_bone.meshify.meshify import _chunk_stage_1_reduction
+
+        assert _chunk_stage_1_reduction(
+            {
+                "use_fixed_edge_simplification": False,
+                "target_reduction": 0.933,
+                "stage_1_reduction_fraction": 0.25,
+            }
+        ) == 0.0
+
+    def test_chunk_reduction_uses_stage_split_when_enabled(self):
+        from mesh_n_bone.meshify.meshify import (
+            _chunk_stage_1_reduction,
+            staged_reductions,
+        )
+
+        config = {
+            "use_fixed_edge_simplification": True,
+            "target_reduction": 0.933,
+            "stage_1_reduction_fraction": 0.25,
+        }
+        expected, _ = staged_reductions(0.933, 0.25, 0.75)
+        assert _chunk_stage_1_reduction(config) == expected
+
     def test_assembly_uses_second_stage_reduction(self, tmp_output_dir, monkeypatch):
         from cloudvolume.mesh import Mesh as CloudVolumeMesh
         from mesh_n_bone.meshify.meshify import Meshify, staged_reductions
@@ -427,6 +452,25 @@ class TestStagedReductions:
 
         _, expected_stage_2 = staged_reductions(0.933, 0.25, 0.75)
         assert reductions == [expected_stage_2]
+
+    def test_zero_reduction_skips_chunk_decimator(self, monkeypatch):
+        from mesh_n_bone.meshify import fixed_edge
+
+        mesh = trimesh.creation.icosphere(subdivisions=1, radius=1.0)
+
+        def fail_decimator(*args, **kwargs):
+            raise AssertionError("decimator should not run")
+
+        monkeypatch.setattr(fixed_edge, "pymeshlab_simplify", fail_decimator)
+        out = fixed_edge.simplify_mesh(
+            mesh,
+            target_reduction=0.0,
+            voxel_size=np.array([1, 1, 1]),
+            block_size=None,
+            fix_edges=True,
+        )
+
+        assert len(out.faces) > 0
 
 
 class TestRepairMeshPymeshlab:


### PR DESCRIPTION
## Summary

Grab-bag of efficiency and robustness improvements driven by real LSF hemibrain runs.

**Thread / I/O concurrency**
- Cap per-worker TBB / OMP / MKL / KMP threads to 1 in the LSF prologue. Without `TBB_NUM_THREADS=1`, each pymeshlab/meshlab call spawned ~N_CPU TBB workers per process, producing load averages >1000 on shared nodes
- Add a shared `_capped_tensorstore_context_spec()` that pins tensorstore's `data_copy`, `file_io`, and `gcs/s3/http` request pools to small fixed limits, embedded in every `ts.open()` spec
- Size-aware read timeouts: small reads keep the 5s default; large remote reads scale up to 120s (`_default_read_timeout_seconds`). Error messages now record the actual attempt timeout

**Block enumeration & sizing**
- Lazy block enumeration via `count_blocks()` / `block_from_index()` (cellmap-analyze-style). Driver no longer materializes the full block list — saves minutes on hemibrain-sized ROIs
- `_default_block_shape_pixels` chooses block size from per-worker RAM and an empirically calibrated processing amplification factor (no more arbitrary block-MB cap)
- `_estimate_block_target_mb_from_dask_config` uses worker memory and amplification to back-calculate the safe block size

**Assembly / multires**
- Plan assembly workers by mesh size so big meshes don't pile onto one node
- Second-stage reduction during assembly when fixed-edge simplification is enabled; disabled-mode short-circuits the per-chunk pass
- Log explicit reasons when multires truncates LODs below `num_lods`
- Ignore the Dask cleanup-race exception after all work is complete

**Sharded-by-default**
- `Meshify(sharded=True)` is now the default. Sharded multires output turns thousands of per-segment HTTP fetches into a handful of range reads inside a few shard files — the right behavior for any production-scale meshing
- Legacy unsharded layout is opt-in via `sharded=False`; the few integration tests that scan per-segment `.index` files opt out via `_BASE_KWARGS`
- README and example notebook updated to reflect the new default

**Other**
- Fix Dask chunk partitioning when `npartitions > num_blocks`
- Pin example notebook install to this branch for colab testing (revert at merge time)