### PR TITLE
Use descent-based minimum empty placeholders; remove auto LOD cap

### DIFF
--- a/src/mesh_n_bone/multires/decimation.py
+++ b/src/mesh_n_bone/multires/decimation.py
@@ -33,7 +33,7 @@ def pyfqmr_decimate(id, lod, input_path, output_path, ext, decimation_factor, ag
         produce faster but lower-quality decimation.
     """
     vertices, faces = mesh_io.mesh_loader(f"{input_path}/{id}{ext}")
-    desired_faces = max(len(faces) // (decimation_factor**lod), 1000)
+    desired_faces = max(len(faces) // (decimation_factor**lod), 4)
     mesh_simplifier = pyfqmr.Simplify()
     mesh_simplifier.setMesh(vertices, faces)
     del vertices, faces

--- a/src/mesh_n_bone/multires/multires.py
+++ b/src/mesh_n_bone/multires/multires.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_TARGET_FACES_PER_LOD0_CHUNK = 25_000
-MAX_AUTO_LOD_GRID_PADDING_RATIO = 2.0
 
 
 def generate_neuroglancer_multires_mesh(
@@ -69,8 +68,6 @@ def generate_neuroglancer_multires_mesh(
 
         vertex_min = None
         vertex_max = None
-        lod_vertex_mins = []
-        lod_vertex_maxs = []
         requested_lods = list(lods)
         requested_lod_count = len(requested_lods)
         lod_face_counts = []
@@ -92,32 +89,25 @@ def generate_neuroglancer_multires_mesh(
                 break
 
             num_faces = len(faces)
-            if num_faces >= previous_num_faces:
+            if num_faces > previous_num_faces:
                 previous_lod, previous_faces = lod_face_counts[-1]
                 lod_truncation_reason = (
                     f"Segment {id} using {idx}/{requested_lod_count} requested "
                     f"LODs; dropping LOD {current_lod} and later because it "
-                    f"has {num_faces} faces, not fewer than LOD "
+                    f"has {num_faces} faces, more than LOD "
                     f"{previous_lod} ({previous_faces} faces)."
                 )
                 break
             lod_face_counts.append((current_lod, num_faces))
-            # LOD-0 bounds drive the chunk grid; union bounds drive
-            # the empty-placeholder envelope (which must cover every
-            # LOD's actual face footprint, not just LOD 0's).
+            # LOD-0 bounds drive the chunk grid.
             if current_lod == 0 and vertices is not None:
                 vertex_min = vertices.min(axis=0)
                 vertex_max = vertices.max(axis=0)
-            if vertices is not None and len(vertices) > 0:
-                lod_vmin = vertices.min(axis=0)
-                lod_vmax = vertices.max(axis=0)
-                lod_vertex_mins.append(lod_vmin)
-                lod_vertex_maxs.append(lod_vmax)
 
             # Capture LOD-0 face count for the chunk-shape heuristic
-            # below. We compute lod_0_box_size AFTER the loop so the
-            # octree_unit cap uses the effective num_lods (after any
-            # face-count truncation), not the requested num_lods.
+            # below. We compute lod_0_box_size AFTER the loop so it
+            # reflects the effective num_lods (after any face-count
+            # truncation), not the requested num_lods.
             if current_lod == 0:
                 lod0_num_faces = num_faces
                 lod0_distances_per_axis = np.ceil(
@@ -141,7 +131,6 @@ def generate_neuroglancer_multires_mesh(
             )
             return
 
-        auto_lod_0_box_size = lod_0_box_size is None
         if lod_0_box_size is None:
             # Surface-area scaling: triangles distribute across the
             # mesh's 2-D surface, so total chunks ∝ N²-on-axis. Use
@@ -162,74 +151,6 @@ def generate_neuroglancer_multires_mesh(
             np.ceil(mesh_extent / lod_0_box_size).astype(int), 1
         )
 
-        if auto_lod_0_box_size:
-            requested_lod_count = len(lods)
-            effective_lod_count = requested_lod_count
-            padding_candidates = []
-            for candidate_lod_count in range(requested_lod_count, 0, -1):
-                octree_unit = 2 ** (candidate_lod_count - 1)
-                padded_chunks_per_axis = (
-                    np.ceil(num_chunks_per_axis / octree_unit).astype(int)
-                    * octree_unit
-                )
-                padding_ratio = np.max(
-                    padded_chunks_per_axis / num_chunks_per_axis
-                )
-                padding_candidates.append(
-                    (
-                        candidate_lod_count,
-                        padded_chunks_per_axis,
-                        padding_ratio,
-                    )
-                )
-                if padding_ratio <= MAX_AUTO_LOD_GRID_PADDING_RATIO:
-                    effective_lod_count = candidate_lod_count
-                    break
-
-            if effective_lod_count < requested_lod_count:
-                requested_padding = padding_candidates[0]
-                selected_padding = next(
-                    candidate
-                    for candidate in padding_candidates
-                    if candidate[0] == effective_lod_count
-                )
-                logger.info(
-                    "Reducing segment %s from %d to %d LODs for auto chunking: "
-                    "LOD0 faces=%d, target_faces_per_lod0_chunk=%d, "
-                    "auto_box_size=%s, mesh_extent=%s, lod0_grid=%s. "
-                    "Requested %d LODs would pad the grid to %s (%.2fx); "
-                    "selected %d LODs pads to %s (%.2fx), max_allowed=%.2fx.",
-                    id,
-                    requested_lod_count,
-                    effective_lod_count,
-                    int(lod0_num_faces),
-                    int(target_faces_per_lod0_chunk),
-                    np.asarray(lod_0_box_size).astype(float).tolist(),
-                    np.asarray(mesh_extent).astype(float).tolist(),
-                    np.asarray(num_chunks_per_axis).astype(int).tolist(),
-                    requested_padding[0],
-                    np.asarray(requested_padding[1]).astype(int).tolist(),
-                    float(requested_padding[2]),
-                    selected_padding[0],
-                    np.asarray(selected_padding[1]).astype(int).tolist(),
-                    float(selected_padding[2]),
-                    MAX_AUTO_LOD_GRID_PADDING_RATIO,
-                )
-                lods = lods[:effective_lod_count]
-                lod_vertex_mins = lod_vertex_mins[:effective_lod_count]
-                lod_vertex_maxs = lod_vertex_maxs[:effective_lod_count]
-
-        # The union bbox is only over retained LODs. Decimated meshes can
-        # drift slightly outside LOD 0; empty-placeholder coverage must
-        # include that retained drift, but not LODs dropped by the auto
-        # padding guard above.
-        if lod_vertex_mins:
-            union_vertex_min = np.min(np.stack(lod_vertex_mins), axis=0)
-            union_vertex_max = np.max(np.stack(lod_vertex_maxs), axis=0)
-        else:
-            union_vertex_min = vertex_min.copy()
-            union_vertex_max = vertex_max.copy()
-
         # Center the mesh within the full octree grid so that
         # Neuroglancer's bounding-box center matches the actual mesh
         # center.
@@ -245,20 +166,6 @@ def generate_neuroglancer_multires_mesh(
             grid_origin,
             np.ceil(vertex_max - full_grid_extent),
             np.floor(vertex_min),
-        )
-
-        # Convert union-of-LOD-vertex bbox to LOD-0 chunk units. This is
-        # the face-correct footprint we list at every LOD: a chunk with
-        # any face in any LOD must have a fragment (possibly empty) at
-        # every other LOD whose chunk contains it, so cross-LOD zoom
-        # transitions don't show two scales side by side.
-        union_lod0_min = np.maximum(
-            np.floor((union_vertex_min - grid_origin) / lod_0_box_size).astype(int),
-            0,
-        )
-        union_lod0_max = np.maximum(
-            np.ceil((union_vertex_max - grid_origin) / lod_0_box_size).astype(int),
-            union_lod0_min + 1,
         )
 
         results = []
@@ -356,8 +263,6 @@ def generate_neuroglancer_multires_mesh(
                     current_lod,
                     lods[: idx + 1],
                     np.asarray(lod_0_box_size, dtype=float),
-                    union_lod0_min=union_lod0_min,
-                    union_lod0_max=union_lod0_max,
                 )
 
                 del fragments

--- a/src/mesh_n_bone/util/mesh_io.py
+++ b/src/mesh_n_bone/util/mesh_io.py
@@ -203,160 +203,168 @@ def zorder_fragments(fragments):
     return list(fragments)
 
 
-def rewrite_index_with_empty_fragments(
-    path, current_lod_fragments,
-    union_lod0_min=None, union_lod0_max=None,
-):
-    """Append a new LOD's fragments to an existing index file.
+def rewrite_index_with_empty_fragments(path, current_lod_fragments):
+    """Append a new LOD's fragments and apply descent-based minimum empties.
 
-    For every LOD this writes the existing non-empty fragments plus
-    empty (offset=0) placeholders covering the *union* of every LOD's
-    vertex bbox in LOD-0 chunk units. Empty placeholders signal to
-    NG's per-chunk LOD selector that the corresponding sub-chunk is
-    genuinely empty (not just unloaded), so NG can replace the parent
-    LOD with finer LODs over those regions cleanly.
+    For an octree to render correctly, every real (non-empty) parent
+    fragment must have all 8 sub-octants listed at the next finer LOD —
+    either as real fragments or as ``offset=0`` empty placeholders.
+    Missing children make NG's "fall back to parent" rule kick in,
+    which over-renders the parent in regions the finer LOD doesn't
+    cover.
 
-    Vertex AABB == triangle AABB for triangular faces, so unioning
-    vertex bboxes is face-correct: a triangle that spans multiple
-    chunks is still bounded by its three vertices' AABB.
+    This function walks the octree top-down from the current top LOD:
+    a position is *reachable* if it's the root, or if it's a sub-octant
+    of a reachable REAL position at the LOD above. Reachable positions
+    that are also real keep their fragment data; reachable positions
+    with no real fragment get a 0-byte empty placeholder. Real
+    fragments NOT in the reachable set are *orphans* (no real-parent
+    chain to the root) — NG can never traverse to them, so they're
+    dropped from both the index and the data file. This matches the
+    hemibrain layout: only emit what NG can actually use.
+
+    Both the ``.index`` file and the mesh data file are rewritten in
+    place. The data file is reordered to z-order per LOD with empties
+    contributing zero bytes, so cumulative offsets line up.
 
     Parameters
     ----------
     path : str
         Base path for the mesh (without ``.index`` suffix). The index
-        file is expected at ``path + ".index"``.
+        file is expected at ``path + ".index"`` and the data file at
+        ``path``.
     current_lod_fragments : list[CompressedFragment]
         Newly created fragments for the next LOD level to be appended.
-    union_lod0_min, union_lod0_max : numpy.ndarray, optional
-        Inclusive-min / exclusive-max LOD-0 chunk indices defining the
-        envelope of chunks to enumerate empty placeholders for. When
-        omitted, falls back to the LOD-0 fragment positions only.
     """
 
     with open(f"{path}.index", mode="rb") as file:
-        file_content = file.read()
+        idx_bytes = file.read()
+    with open(path, mode="rb") as file:
+        data_blob = file.read()
 
-    chunk_shape, file_content = unpack_and_remove("f", 3, file_content)
-    grid_origin, file_content = unpack_and_remove("f", 3, file_content)
-    num_lods, file_content = unpack_and_remove("I", 1, file_content)
-    lod_scales, file_content = unpack_and_remove("f", num_lods, file_content)
-    vertex_offsets, file_content = unpack_and_remove("f", num_lods * 3, file_content)
+    o = 0
+    chunk_shape = np.frombuffer(idx_bytes, dtype="<f4", count=3, offset=o); o += 12
+    grid_origin = np.frombuffer(idx_bytes, dtype="<f4", count=3, offset=o); o += 12
+    num_existing_lods = struct.unpack_from("<I", idx_bytes, o)[0]; o += 4
+    o += 4 * num_existing_lods            # skip lod_scales
+    o += 12 * num_existing_lods           # skip vertex_offsets
+    nfpl_existing = list(struct.unpack_from(
+        f"<{num_existing_lods}I", idx_bytes, o
+    )); o += 4 * num_existing_lods
 
-    num_fragments_per_lod, file_content = unpack_and_remove("I", num_lods, file_content)
-    if type(num_fragments_per_lod) == int:
-        num_fragments_per_lod = np.array([num_fragments_per_lod])
+    existing_per_lod = []  # list of (positions ndarray, sizes ndarray) preserving order
+    for lod in range(num_existing_lods):
+        n = nfpl_existing[lod]
+        pos = np.frombuffer(
+            idx_bytes, dtype="<u4", count=n * 3, offset=o
+        ).reshape(3, n).T.copy()
+        o += 12 * n
+        sz = np.frombuffer(
+            idx_bytes, dtype="<u4", count=n, offset=o
+        ).copy()
+        o += 4 * n
+        existing_per_lod.append((pos, sz))
 
-    all_current_fragment_positions = []
-    all_current_fragment_offsets = []
+    # Append the new LOD's fragments.
+    new_lod_positions = np.asarray(
+        [fragment.position for fragment in current_lod_fragments], dtype=np.uint32
+    ).reshape(-1, 3)
+    new_lod_sizes = np.asarray(
+        [fragment.offset for fragment in current_lod_fragments], dtype=np.uint32
+    ).reshape(-1)
+    existing_per_lod.append((new_lod_positions, new_lod_sizes))
+    num_lods = num_existing_lods + 1
+    top = num_lods - 1
 
+    # Identify REAL (non-empty) positions at every LOD. Empties from
+    # prior incremental writes are filtered out — descent recomputes
+    # them from the current real footprint.
+    real_pos_per_lod = [
+        set(map(tuple, p[s > 0].tolist())) for (p, s) in existing_per_lod
+    ]
+
+    # Descent: reachable positions are sub-octants of REAL reachable
+    # positions one level up. The root is reachable by definition.
+    reachable = [set() for _ in range(num_lods)]
+    if real_pos_per_lod[top]:
+        reachable[top] = real_pos_per_lod[top].copy()
+        for k in range(top - 1, -1, -1):
+            for (X, Y, Z) in reachable[k + 1] & real_pos_per_lod[k + 1]:
+                for a in (0, 1):
+                    for b in (0, 1):
+                        for c in (0, 1):
+                            reachable[k].add((2 * X + a, 2 * Y + b, 2 * Z + c))
+
+    # Walk the existing data blob LOD-by-LOD in its current listed
+    # order, extracting bytes for reachable real fragments. Drop bytes
+    # for orphan (real-but-unreachable) fragments; ignore empties
+    # (they contribute zero bytes anyway).
+    new_data_segments = []
+    new_positions_per_lod = []
+    new_sizes_per_lod = []
+    byte_off = 0
     for lod in range(num_lods):
-        fragment_positions, file_content = unpack_and_remove(
-            "I", num_fragments_per_lod[lod] * 3, file_content
+        pos, sz = existing_per_lod[lod]
+        kept = []  # (position_tuple, size, data_bytes)
+        for i in range(len(pos)):
+            s = int(sz[i])
+            p = tuple(pos[i].tolist())
+            if s > 0 and p in reachable[lod]:
+                kept.append((p, s, data_blob[byte_off : byte_off + s]))
+            byte_off += s
+        # Add empties at sub-octant positions reachable but lacking a
+        # real fragment — keeps NG's octree carve-out complete under
+        # each real parent.
+        real_kept = {p for (p, _, _) in kept}
+        for p in reachable[lod]:
+            if p not in real_kept:
+                kept.append((p, 0, b""))
+        # Z-curve order across the combined real + empty list.
+        kept.sort(key=cmp_to_key(lambda a, b: _cmp_zorder(a[0], b[0])))
+        new_positions_per_lod.append(
+            np.array([p for (p, _, _) in kept], dtype=np.uint32).reshape(-1, 3)
         )
-        fragment_positions = fragment_positions.reshape((3, -1)).T
-        fragment_offsets, file_content = unpack_and_remove(
-            "I", num_fragments_per_lod[lod], file_content
+        new_sizes_per_lod.append(
+            np.array([s for (_, s, _) in kept], dtype=np.uint32)
         )
-        if type(fragment_offsets) == int:
-            fragment_offsets = np.array([fragment_offsets])
-        all_current_fragment_positions.append(fragment_positions.astype(int))
-        all_current_fragment_offsets.append(fragment_offsets.tolist())
+        for (_, _, b) in kept:
+            if b:
+                new_data_segments.append(b)
 
-    current_lod = num_lods
-    num_lods += 1
-    all_current_fragment_positions.append(
-        np.asarray([fragment.position for fragment in current_lod_fragments]).astype(int)
-    )
-    all_current_fragment_offsets.append(
-        [fragment.offset for fragment in current_lod_fragments]
-    )
+    nfpl_new = np.array([len(p) for p in new_positions_per_lod], dtype=np.uint32)
+    lod_scales = np.array([2 ** i for i in range(num_lods)], dtype=np.float32)
+    vertex_offsets = np.zeros((num_lods, 3), dtype=np.float32)
 
-    # Use caller-provided union bbox if given, else fall back to the
-    # LOD-0 fragment positions only.
-    if union_lod0_min is None or union_lod0_max is None:
-        lod0_positions = np.asarray(all_current_fragment_positions[0]).reshape(-1, 3)
-        if lod0_positions.size > 0:
-            union_lod0_min = lod0_positions.min(axis=0).astype(int)
-            union_lod0_max = (lod0_positions.max(axis=0) + 1).astype(int)
-    else:
-        union_lod0_min = np.asarray(union_lod0_min, dtype=int)
-        union_lod0_max = np.asarray(union_lod0_max, dtype=int)
-
-    all_missing_fragment_positions = []
-    for lod in range(num_lods):
-        scale = 2 ** lod
-        if union_lod0_min is None:
-            required = set()
-        else:
-            lo = (union_lod0_min // scale).astype(int)
-            hi = ((union_lod0_max + scale - 1) // scale).astype(int)
-            required = {
-                (x, y, z)
-                for x in range(lo[0], hi[0])
-                for y in range(lo[1], hi[1])
-                for z in range(lo[2], hi[2])
-            }
-        existing = set(map(tuple, all_current_fragment_positions[lod]))
-        all_missing_fragment_positions.append(required - existing)
-
-    num_fragments_per_lod = []
-    all_fragment_positions = []
-    all_fragment_offsets = []
-    for lod in range(num_lods):
-        if len(all_missing_fragment_positions[lod]) > 0:
-            lod_fragment_positions = list(all_missing_fragment_positions[lod]) + list(
-                all_current_fragment_positions[lod]
-            )
-            lod_fragment_offsets = (
-                list(np.zeros(len(all_missing_fragment_positions[lod])))
-                + all_current_fragment_offsets[lod]
-            )
-        else:
-            lod_fragment_positions = all_current_fragment_positions[lod]
-            lod_fragment_offsets = all_current_fragment_offsets[lod]
-
-        lod_fragment_offsets, lod_fragment_positions = zip(
-            *sorted(
-                zip(lod_fragment_offsets, lod_fragment_positions),
-                key=cmp_to_key(lambda x, y: _cmp_zorder(x[1], y[1])),
-            )
-        )
-        all_fragment_positions.append(lod_fragment_positions)
-        all_fragment_offsets.append(lod_fragment_offsets)
-        num_fragments_per_lod.append(len(all_fragment_offsets[lod]))
-
-    num_fragments_per_lod = np.array(num_fragments_per_lod)
-    lod_scales = np.array([2**i for i in range(num_lods)])
-    vertex_offsets = np.array([[0.0, 0.0, 0.0] for _ in range(num_lods)])
-    with open(f"{path}.index_with_empty_fragments", "ab") as f:
-        f.write(chunk_shape.astype("<f").tobytes())
-        f.write(grid_origin.astype("<f").tobytes())
-
+    tmp_index_path = f"{path}.index_tmp"
+    with open(tmp_index_path, "wb") as f:
+        f.write(chunk_shape.astype("<f4").tobytes())
+        f.write(grid_origin.astype("<f4").tobytes())
         f.write(struct.pack("<I", num_lods))
-        f.write(lod_scales.astype("<f").tobytes())
-        f.write(vertex_offsets.astype("<f").tobytes(order="C"))
+        f.write(lod_scales.tobytes())
+        f.write(vertex_offsets.tobytes(order="C"))
+        f.write(nfpl_new.tobytes())
+        for pos, sz in zip(new_positions_per_lod, new_sizes_per_lod):
+            f.write(pos.T.astype("<u4").tobytes(order="C"))
+            f.write(sz.astype("<u4").tobytes())
 
-        f.write(num_fragments_per_lod.astype("<I").tobytes())
+    tmp_data_path = f"{path}.tmp"
+    with open(tmp_data_path, "wb") as f:
+        for seg in new_data_segments:
+            f.write(seg)
 
-        for lod in range(num_lods):
-            fragment_positions = np.array(all_fragment_positions[lod]).reshape(-1, 3)
-            fragment_offsets = np.array(all_fragment_offsets[lod]).reshape(-1)
-
-            f.write(fragment_positions.T.astype("<I").tobytes(order="C"))
-            f.write(fragment_offsets.astype("<I").tobytes(order="C"))
-
-    os.system(f"mv {path}.index_with_empty_fragments {path}.index")
+    os.replace(tmp_index_path, f"{path}.index")
+    os.replace(tmp_data_path, path)
 
 
 def write_index_file(
     path, grid_origin, fragments, current_lod, lods, chunk_shape,
-    union_lod0_min=None, union_lod0_max=None,
 ):
     """Write or update the ``.index`` file for a multi-LOD Draco mesh.
 
     If this is the first LOD or no index file exists yet, a new file is
     created. Otherwise the existing index is rewritten via
-    ``rewrite_index_with_empty_fragments`` to incorporate the new LOD.
+    ``rewrite_index_with_empty_fragments`` to incorporate the new LOD
+    and apply descent-based minimum empties.
 
     Parameters
     ----------
@@ -372,8 +380,6 @@ def write_index_file(
         All LOD levels that have been (or will be) generated.
     chunk_shape : numpy.ndarray
         Size of a single LOD 0 chunk in model coordinates, shape ``(3,)``.
-    union_lod0_min, union_lod0_max : numpy.ndarray, optional
-        Forwarded to ``rewrite_index_with_empty_fragments`` (see there).
     """
     lods = [lod for lod in lods if lod <= current_lod]
 
@@ -400,10 +406,7 @@ def write_index_file(
                 .tobytes(order="C")
             )
     else:
-        rewrite_index_with_empty_fragments(
-            path, fragments,
-            union_lod0_min=union_lod0_min, union_lod0_max=union_lod0_max,
-        )
+        rewrite_index_with_empty_fragments(path, fragments)
 
 
 def write_mesh_file(path, fragments):
@@ -435,7 +438,6 @@ def write_mesh_file(path, fragments):
 
 def write_mesh_files(
     mesh_directory, object_id, grid_origin, fragments, current_lod, lods, chunk_shape,
-    union_lod0_min=None, union_lod0_max=None,
 ):
     """Write the mesh data and index files for a single segment.
 
@@ -458,12 +460,6 @@ def write_mesh_files(
         All LOD levels that have been (or will be) generated.
     chunk_shape : numpy.ndarray
         Size of a single LOD 0 chunk in model coordinates, shape ``(3,)``.
-    union_lod0_min, union_lod0_max : numpy.ndarray, optional
-        Inclusive-min / exclusive-max bounds (in LOD-0 chunk index units)
-        of the union of every LOD's vertex bbox. Used by
-        ``rewrite_index_with_empty_fragments`` to enumerate empty
-        placeholders covering the actual face footprint of every LOD.
-        If omitted, falls back to the LOD-0 fragment positions only.
     """
     path = mesh_directory + "/" + object_id
     if len(fragments) > 0:
@@ -471,5 +467,4 @@ def write_mesh_files(
         fragments = write_mesh_file(path, fragments)
         write_index_file(
             path, grid_origin, fragments, current_lod, lods, chunk_shape,
-            union_lod0_min=union_lod0_min, union_lod0_max=union_lod0_max,
         )

--- a/tests/test_integration_multires.py
+++ b/tests/test_integration_multires.py
@@ -518,22 +518,24 @@ class TestLodTruncation:
             "The last valid LOD may be getting dropped."
         )
 
-    def test_lod_truncation_on_non_decreasing_faces(self, tmp_output_dir, caplog):
-        """If a higher LOD has >= faces than the previous, truncate there."""
+    def test_lod_truncation_on_increasing_faces(self, tmp_output_dir, caplog):
+        """If a higher LOD has strictly more faces than the previous, truncate."""
         output_path = os.path.join(tmp_output_dir, "truncation_test")
         mesh_lods = os.path.join(output_path, "mesh_lods")
 
         # LOD 0: 642 faces (icosphere subdiv=3)
-        mesh = trimesh.creation.icosphere(subdivisions=3, radius=50.0)
-        mesh.vertices += 100
+        mesh_lod0 = trimesh.creation.icosphere(subdivisions=3, radius=50.0)
+        mesh_lod0.vertices += 100
         s0_dir = os.path.join(mesh_lods, "s0")
         os.makedirs(s0_dir)
-        mesh.export(os.path.join(s0_dir, "1.ply"))
+        mesh_lod0.export(os.path.join(s0_dir, "1.ply"))
 
-        # LOD 1: SAME mesh (not decimated) — should trigger truncation
+        # LOD 1: 2562 faces (icosphere subdiv=4) — strictly more than LOD 0
+        mesh_lod1 = trimesh.creation.icosphere(subdivisions=4, radius=50.0)
+        mesh_lod1.vertices += 100
         s1_dir = os.path.join(mesh_lods, "s1")
         os.makedirs(s1_dir)
-        mesh.export(os.path.join(s1_dir, "1.ply"))
+        mesh_lod1.export(os.path.join(s1_dir, "1.ply"))
 
         with caplog.at_level(logging.INFO, logger="mesh_n_bone.multires.multires"):
             generate_neuroglancer_multires_mesh(
@@ -549,13 +551,40 @@ class TestLodTruncation:
         with open(index_file, "rb") as f:
             data = f.read()
         num_lods = struct.unpack("<I", data[24:28])[0]
-        # LOD 1 has same face count as LOD 0, so it should be truncated
+        # LOD 1 has more faces than LOD 0, so it should be truncated
         assert num_lods == 1
         assert any(
             "dropping LOD 1 and later because it has" in r.message
-            and "not fewer than LOD 0" in r.message
+            and "more than LOD 0" in r.message
             for r in caplog.records
         )
+
+    def test_lod_retained_on_equal_faces(self, tmp_output_dir):
+        """Equal face counts across LODs are retained (pyfqmr floor plateau)."""
+        output_path = os.path.join(tmp_output_dir, "equal_faces_test")
+        mesh_lods = os.path.join(output_path, "mesh_lods")
+
+        mesh = trimesh.creation.icosphere(subdivisions=3, radius=50.0)
+        mesh.vertices += 100
+        for lod in (0, 1):
+            lod_dir = os.path.join(mesh_lods, f"s{lod}")
+            os.makedirs(lod_dir)
+            mesh.export(os.path.join(lod_dir, "1.ply"))
+
+        generate_neuroglancer_multires_mesh(
+            id=1,
+            num_subtask_workers=1,
+            output_path=output_path,
+            lods=[0, 1],
+            original_ext=".ply",
+            lod_0_box_size=None,
+        )
+
+        index_file = os.path.join(output_path, "multires", "1.index")
+        with open(index_file, "rb") as f:
+            data = f.read()
+        num_lods = struct.unpack("<I", data[24:28])[0]
+        assert num_lods == 2
 
     def test_lod_truncation_on_missing_candidate_mesh(self, tmp_output_dir, caplog):
         """If a requested higher LOD mesh is missing, log why it was dropped."""
@@ -664,16 +693,16 @@ class TestLodTruncation:
             "mesh extent, not octree_unit."
         )
 
-    def test_auto_lods_truncated_to_bound_grid_padding(self, tmp_output_dir, caplog):
-        """Auto chunking treats requested LODs as an upper bound.
-
-        Small meshes should not be forced into a deep octree whose padded
-        grid is much larger than the object bounds; that inflated manifest
-        footprint can keep coarse LODs visible in Neuroglancer.
+    def test_auto_lods_keeps_all_requested(self, tmp_output_dir):
+        """Auto chunking now keeps every requested LOD that has fewer
+        faces than the previous LOD. The persistent-coarse-LOD overlay
+        that motivated the old padding cap is handled by the partition
+        snap fix + descent-based minimum empties, so we no longer drop
+        LODs based on padded-grid size.
         """
         import pyfqmr
 
-        output_path = os.path.join(tmp_output_dir, "auto_lod_padding")
+        output_path = os.path.join(tmp_output_dir, "auto_lod_no_cap")
         mesh_lods = os.path.join(output_path, "mesh_lods")
         mesh = trimesh.creation.icosphere(subdivisions=4, radius=50.0)
         mesh.vertices += 100
@@ -694,29 +723,21 @@ class TestLodTruncation:
                 v, f, _ = simplifier.getMesh()
                 trimesh.Trimesh(v, f).export(os.path.join(lod_dir, "1.ply"))
 
-        with caplog.at_level(logging.INFO, logger="mesh_n_bone.multires.multires"):
-            generate_neuroglancer_multires_mesh(
-                id=1,
-                num_subtask_workers=1,
-                output_path=output_path,
-                lods=[0, 1, 2, 3],
-                original_ext=".ply",
-                lod_0_box_size=None,
-            )
+        generate_neuroglancer_multires_mesh(
+            id=1,
+            num_subtask_workers=1,
+            output_path=output_path,
+            lods=[0, 1, 2, 3],
+            original_ext=".ply",
+            lod_0_box_size=None,
+        )
 
         index_file = os.path.join(output_path, "multires", "1.index")
         with open(index_file, "rb") as f:
             data = f.read()
         num_lods = struct.unpack("<I", data[24:28])[0]
-        assert num_lods == 2, (
-            "Default auto chunking should drop excessive LODs for this "
-            f"small mesh; got {num_lods} LODs."
-        )
-        assert any(
-            "Reducing segment 1 from 4 to 2 LODs for auto chunking" in r.message
-            and "auto_box_size=" in r.message
-            and "lod0_grid=" in r.message
-            for r in caplog.records
+        assert num_lods == 4, (
+            f"All 4 requested LODs should be retained; got {num_lods}."
         )
 
     def test_three_lods_all_valid(self, tmp_output_dir):


### PR DESCRIPTION
@stuarteberg
## Summary

- Replaces the union-vertex-bbox empty-placeholder envelope in `rewrite_index_with_empty_fragments` with a top-down octree-descent algorithm. Each real reachable parent gets all 8 sub-octants listed (real or empty); orphan fragments unreachable from the root via a real-parent chain are dropped from both the index and the data file. Matches hemibrain's "only emit what NG actually traverses" layout.
- Removes `MAX_AUTO_LOD_GRID_PADDING_RATIO` and its truncation loop. The cap was an empirical workaround for a persistent-coarse-LOD overlay that turned out to be caused by Draco subchunk triangle spill, which the partition-q snap fix in 668d9a6 already addresses.
- Loosens the per-LOD plateau guard from `>=` to `>` so equal face counts (pyfqmr floor wobble) no longer truncate the pyramid.
- Lowers the pyfqmr face floor in `decimation.py` from 1000 to 4 so coarse LODs can actually shrink past the floor where the plateau guard used to trip.
- Updates tests: renamed `test_lod_truncation_on_non_decreasing_faces` → `test_lod_truncation_on_increasing_faces` (strict-greater); added `test_lod_retained_on_equal_faces`; replaced `test_auto_lods_truncated_to_bound_grid_padding` with `test_auto_lods_keeps_all_requested` (all requested LODs survive).