### PR TITLE
Preserve fractional OME-NGFF translation precision in mesh vertices

### DIFF
--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -21,6 +21,7 @@ from mesh_n_bone.util.zarr_io import (
     open_dataset,
     split_dataset_path,
     read_raw_voxel_size,
+    read_raw_offset,
     _read_attrs,
     _get_multiscales,
     _extract_ome_scale_translation,
@@ -884,8 +885,13 @@ class Meshify:
         driver = _detect_zarr_driver(self._dataset_path)
         self._swap_axes = driver in ("n5", "neuroglancer_precomputed")
 
-        # Get true (possibly non-integer) voxel size from the underlying data
+        # Get true (possibly non-integer) voxel size and offset from
+        # the underlying data. self.true_offset is the float-precision
+        # OME translation / funlib offset; self.roi.offset stays
+        # integer for funlib Roi arithmetic, and the final mesh
+        # vertices get corrected with true_offset before output.
         self.true_voxel_size = np.array(read_raw_voxel_size(self.segmentation_array))
+        self.true_offset = np.array(read_raw_offset(self.segmentation_array))
 
         # Check if voxel_size is just defaults (1,1,1) and
         # try OME-NGFF multiscales metadata from the parent zarr group.
@@ -924,6 +930,13 @@ class Meshify:
                 self.segmentation_array.roi = Roi(
                     ome_offset_coord, Coordinate(array_shape) * ome_voxel_size_coord
                 )
+                # Track the float-precision OME translation so the
+                # final-mesh rescale can place vertices at sub-unit
+                # positions even when ome_offset_coord rounds them.
+                if ome_offset is not None:
+                    self.true_offset = np.array(ome_offset, dtype=float)
+                else:
+                    self.true_offset = np.zeros(3, dtype=float)
 
         if roi is not None:
             if not isinstance(roi, Roi):
@@ -1646,15 +1659,33 @@ class Meshify:
         except Exception as e:
             raise Exception(f"{mesh_id} failed, with error: {e}")
 
-        # Correct for difference between funlib voxel sizes (rounded) and actual
-        if list(self.true_voxel_size) != list(self.output_voxel_size_funlib):
+        # Correct for differences between funlib's integer voxel_size /
+        # offset (used during marching cubes and Roi math) and the true
+        # float-precision values from OME-NGFF translation / scale.
+        # Rewriting from voxel-index space gives:
+        #   true_pos = true_offset + true_voxel * (int_pos - int_offset) / int_voxel
+        #            = true_offset + scale * (int_pos - int_offset)
+        voxel_mismatch = (
+            list(self.true_voxel_size) != list(self.output_voxel_size_funlib)
+        )
+        true_offset_attr = getattr(self, "true_offset", None)
+        roi_attr = getattr(self, "roi", None)
+        offset_mismatch = False
+        if true_offset_attr is not None and roi_attr is not None:
+            int_offset_xyz = np.array(roi_attr.offset[::-1], dtype=float)
+            true_offset_xyz = np.array(true_offset_attr[::-1], dtype=float)
+            offset_mismatch = not np.allclose(int_offset_xyz, true_offset_xyz)
+        if voxel_mismatch or offset_mismatch:
             scale = np.array(self.true_voxel_size[::-1]) / np.array(
                 self.output_voxel_size_funlib[::-1]
             )
-            offset_xyz = np.array(self.roi.offset[::-1], dtype=float)
-            mesh.vertices -= offset_xyz
+            int_offset_xyz = np.array(self.roi.offset[::-1], dtype=float)
+            true_offset_xyz = np.array(
+                getattr(self, "true_offset", self.roi.offset)[::-1], dtype=float
+            )
+            mesh.vertices -= int_offset_xyz
             mesh.vertices *= scale
-            mesh.vertices += offset_xyz * scale
+            mesh.vertices += true_offset_xyz
 
         from mesh_n_bone.util.neuroglancer import (
             write_ngmesh,

--- a/src/mesh_n_bone/util/zarr_io.py
+++ b/src/mesh_n_bone/util/zarr_io.py
@@ -456,6 +456,27 @@ def read_raw_voxel_size(ds):
     return tuple(float(v) for v in ds.voxel_size)
 
 
+def read_raw_offset(ds):
+    """Return the float offset / OME translation, preserving non-integer precision.
+
+    Same source-resolution as :func:`_read_voxel_size_offset` but does
+    not round. Falls back to ``ds.roi.offset`` (already a Coordinate)
+    when no metadata source declares a value.
+    """
+    parent_attrs = getattr(ds.data, "parent_attrs", None) or _read_parent_attrs(ds)
+    dataset_name = (
+        getattr(ds.data, "dataset_name", None)
+        or _path_basename(getattr(ds, "_dataset_path", ""))
+        or None
+    )
+    _, offset = _resolve_voxel_size_offset(
+        ds.data.attrs, parent_attrs, dataset_name,
+    )
+    if offset is not None:
+        return tuple(float(v) for v in offset)
+    return tuple(float(v) for v in ds.roi.offset)
+
+
 def _get_multiscales(attrs):
     """Return the OME-Zarr ``multiscales`` list, or ``None``.
 

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -18,6 +18,7 @@ from mesh_n_bone.util.zarr_io import (
     _read_transforms,
     _read_voxel_size_offset,
     open_dataset,
+    read_raw_offset,
     read_raw_voxel_size,
     split_dataset_path,
 )
@@ -170,6 +171,33 @@ class TestOpenDatasetOmeFallback:
         ds = open_dataset(*os.path.split(path))
         raw = read_raw_voxel_size(ds)
         assert raw == (8.0, 16.0, 32.0)
+
+    @pytest.mark.parametrize("ome_version", ["0.4", "0.5"])
+    def test_read_raw_offset_preserves_fractional_translation(
+        self, tmp_output_dir, ome_version,
+    ):
+        # OME translation with sub-unit precision must survive the
+        # parent-traversal path used by read_raw_offset; the rounded
+        # ds.roi.offset would otherwise drop the fraction.
+        zarr_path = os.path.join(tmp_output_dir, f"frac_trans_{ome_version}.zarr")
+        root = zarr.open_group(zarr_path, mode="w", zarr_format=2)
+        ds_path = "s0"
+        root.create_array(
+            ds_path,
+            data=np.zeros((4, 4, 4), dtype=np.uint32),
+            chunks=(4, 4, 4),
+        )
+        ms = _multiscales_block([8.0, 8.0, 8.0], [10.5, 20.25, 30.125])
+        if ome_version == "0.4":
+            root.attrs["multiscales"] = ms
+        else:
+            root.attrs["ome"] = {"multiscales": ms, "version": "0.5"}
+
+        ds = open_dataset(zarr_path, ds_path)
+        # ds.roi.offset is the rounded Coordinate (integer truncation/round).
+        # The raw accessor must keep the floats verbatim.
+        raw_offset = read_raw_offset(ds)
+        assert raw_offset == (10.5, 20.25, 30.125)
 
     def test_open_http_zarr_without_extension(
         self, tmp_output_dir, _http_directory_server,


### PR DESCRIPTION
@stuarteberg
## Summary

- Adds `read_raw_offset()` in `util/zarr_io.py` — a float-precision OME translation accessor parallel to the existing `read_raw_voxel_size()`. Reuses `_resolve_voxel_size_offset`, so it picks up the same metadata sources (funlib/N5 then OME multiscales) without rounding.
- Plumbs `self.true_offset` through `Meshify.__init__` alongside `self.true_voxel_size`. Also updates it in the OME `voxel_size==(1,1,1)` branch so the float translation survives even when `ome_offset_coord` rounds to integer for the funlib `Roi`.
- In `_assemble_mesh`'s post-mesh rescale block, places vertices at `true_offset + scale * (int_pos - int_offset)` instead of `int_offset * scale + scale * (int_pos - int_offset)`. Recovers sub-unit translation precision that was previously lost in the `Coordinate(int(round(v)))` cast. The rescale now also fires when only the offset has fractional precision (previously it only fired on voxel-size mismatch).
- Adds `test_read_raw_offset_preserves_fractional_translation` for OME-Zarr v0.4 and v0.5 to lock in the float behavior.