### PR TITLE
Anonymous S3 credentials by default, drop OpenOrganelle open from ~7s to ~0.2s

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -6075,8 +6075,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: .
   name: mesh-n-bone
-  version: 0.5.0
-  sha256: cbd51e2099e25158e6671523a78cfb3250314b4ba017994b0ecf287bae60c943
+  version: 0.6.0
+  sha256: ff0adf97b14f0edf58a4f19bf36c4849de309ebeea8e72590a2fda6891afc31b
   requires_dist:
   - numpy
   - trimesh>=4.6.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mesh-n-bone"
-version = "0.5.0"
+version = "0.6.0"
 description = "Unified tool for mesh generation, multiresolution mesh creation, skeletonization, and analysis."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mesh_n_bone/util/zarr_io.py
+++ b/src/mesh_n_bone/util/zarr_io.py
@@ -19,6 +19,37 @@ logger = logging.getLogger(__name__)
 _REMOTE_SCHEMES = {"http", "https", "gs", "s3"}
 
 
+def _should_use_anonymous_s3(anonymous):
+    """Resolve whether to inject anonymous S3 credentials.
+
+    When ``anonymous`` is ``None`` (default), use anonymous unless any
+    of ``AWS_ACCESS_KEY_ID``, ``AWS_PROFILE``, or ``AWS_ENDPOINT_URL``
+    is set in the environment:
+
+      - ``AWS_ACCESS_KEY_ID``: explicit credentials present.
+      - ``AWS_PROFILE``: user picked a credential profile.
+      - ``AWS_ENDPOINT_URL``: moto/MinIO/self-hosted S3 — typically
+        needs credentials and overrides anonymous behavior.
+
+    Without one of these, tensorstore would walk the IMDS / web-
+    identity chain and time out on non-EC2 machines (~2 s per provider,
+    ~7 s total). Injecting ``aws_credentials={"type": "anonymous"}``
+    short-circuits the entire chain, dropping OpenOrganelle open+read
+    from ~7 s to ~0.2 s.
+
+    Trade-off: a ``~/.aws/credentials`` user with no ``AWS_PROFILE``
+    in the environment falls through to anonymous. For
+    OpenOrganelle/COSEM reads (the headline use case) that's still
+    fine; for private-bucket reads they need to ``export
+    AWS_PROFILE=default`` or set ``AWS_ACCESS_KEY_ID``.
+    """
+    if anonymous is not None:
+        return bool(anonymous)
+    return not any(
+        os.environ.get(k) for k in ("AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AWS_ENDPOINT_URL")
+    )
+
+
 def _is_http_url(path):
     """Return True if *path* is an HTTP(S) URL."""
     return urlparse(str(path)).scheme in {"http", "https"}
@@ -72,7 +103,7 @@ def _path_basename(path):
     return os.path.basename(path)
 
 
-def kvstore_for_path(path):
+def kvstore_for_path(path, anonymous=None):
     """Build a TensorStore kvstore spec for *path* (any supported scheme).
 
     Returns ``(kvstore_dict, normalized_path)`` where ``normalized_path``
@@ -81,6 +112,16 @@ def kvstore_for_path(path):
 
     Supported schemes: ``gs``, ``s3``, ``http``, ``https``, ``file``,
     plus a bare local filesystem path.
+
+    For ``s3`` URLs, ``anonymous`` controls whether to inject
+    ``aws_credentials={"type": "anonymous"}`` into the spec. When
+    ``None`` (default) the choice is auto-detected via
+    ``_should_use_anonymous_s3``: explicit env-var control via
+    ``AWS_NO_SIGN_REQUEST``, otherwise anonymous when no AWS
+    credentials are configured in the environment. This avoids the
+    multi-second IMDS lookup for public buckets like OpenOrganelle and
+    COSEM on machines with no AWS credentials, while still using the
+    user's configured credentials when they exist.
     """
     inner = _strip_precomputed_prefix(path)
     parsed = urlparse(inner)
@@ -91,10 +132,10 @@ def kvstore_for_path(path):
             parsed.path.lstrip("/"),
         )
     if scheme == "s3":
-        return (
-            {"driver": "s3", "bucket": parsed.netloc},
-            parsed.path.lstrip("/"),
-        )
+        spec = {"driver": "s3", "bucket": parsed.netloc}
+        if _should_use_anonymous_s3(anonymous):
+            spec["aws_credentials"] = {"type": "anonymous"}
+        return (spec, parsed.path.lstrip("/"))
     if scheme in ("http", "https"):
         return (
             {"driver": "http", "base_url": f"{scheme}://{parsed.netloc}"},

--- a/tests/test_precomputed_io.py
+++ b/tests/test_precomputed_io.py
@@ -68,11 +68,20 @@ class TestKvstoreForUrl:
         assert kv == {"driver": "gcs", "bucket": "my-bucket"}
         assert path == "data/segmentation"
 
-    def test_s3_url(self):
+    def test_s3_url(self, monkeypatch):
+        # With no AWS env vars set, the S3 kvstore now defaults to anonymous
+        # credentials to avoid the multi-second IMDS / credential-chain
+        # timeout on public buckets like OpenOrganelle. See
+        # ``_should_use_anonymous_s3`` in zarr_io.
+        for k in ("AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AWS_ENDPOINT_URL"):
+            monkeypatch.delenv(k, raising=False)
         kv, path = precomputed_io._kvstore_for_url(
             "s3://my-bucket/path/to/seg"
         )
-        assert kv == {"driver": "s3", "bucket": "my-bucket"}
+        assert kv == {
+            "driver": "s3", "bucket": "my-bucket",
+            "aws_credentials": {"type": "anonymous"},
+        }
         assert path == "path/to/seg"
 
     def test_http_url(self):

--- a/tests/test_zarr_io.py
+++ b/tests/test_zarr_io.py
@@ -493,3 +493,69 @@ class TestFunlibHelper:
         }
         vs, _ = _read_funlib_voxel_offset(attrs)
         assert vs == [4.0, 4.0, 4.0]
+
+
+class TestS3AnonymousCredentials:
+    """When no AWS credentials are configured in the environment, the
+    S3 kvstore spec must include ``aws_credentials: {type: anonymous}``
+    so tensorstore skips the multi-second IMDS / credential-chain
+    timeout on every fresh OpenOrganelle / COSEM read (~7s -> ~0.2s).
+
+    The heuristic checks three env vars (AWS_ACCESS_KEY_ID, AWS_PROFILE,
+    AWS_ENDPOINT_URL). If any is set, the user has explicit
+    intent — credentials, profile, or a moto/MinIO endpoint that
+    needs credentials — so we don't override."""
+
+    @pytest.fixture
+    def clean_aws_env(self, monkeypatch):
+        for k in ("AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AWS_ENDPOINT_URL"):
+            monkeypatch.delenv(k, raising=False)
+
+    def test_anonymous_when_no_aws_env_vars(self, clean_aws_env):
+        from mesh_n_bone.util.zarr_io import kvstore_for_path
+        spec, path = kvstore_for_path("s3://openorganelle/data.zarr")
+        assert spec["driver"] == "s3"
+        assert spec["bucket"] == "openorganelle"
+        assert spec.get("aws_credentials") == {"type": "anonymous"}
+        assert path == "data.zarr"
+
+    def test_no_anonymous_when_access_key_set(self, clean_aws_env, monkeypatch):
+        from mesh_n_bone.util.zarr_io import kvstore_for_path
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA...")
+        spec, _ = kvstore_for_path("s3://private/data.zarr")
+        assert "aws_credentials" not in spec
+
+    def test_no_anonymous_when_profile_set(self, clean_aws_env, monkeypatch):
+        from mesh_n_bone.util.zarr_io import kvstore_for_path
+        monkeypatch.setenv("AWS_PROFILE", "default")
+        spec, _ = kvstore_for_path("s3://private/data.zarr")
+        assert "aws_credentials" not in spec
+
+    def test_no_anonymous_when_endpoint_url_set(self, clean_aws_env, monkeypatch):
+        from mesh_n_bone.util.zarr_io import kvstore_for_path
+        monkeypatch.setenv("AWS_ENDPOINT_URL", "http://localhost:5000")
+        spec, _ = kvstore_for_path("s3://moto-bucket/data.zarr")
+        assert "aws_credentials" not in spec
+
+    def test_explicit_anonymous_kwarg_wins(self, clean_aws_env, monkeypatch):
+        from mesh_n_bone.util.zarr_io import kvstore_for_path
+        # Force anonymous=False even with no env vars
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        spec, _ = kvstore_for_path("s3://bucket/data.zarr", anonymous=False)
+        assert "aws_credentials" not in spec
+        # Force anonymous=True even with AWS_ACCESS_KEY_ID set
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA...")
+        spec, _ = kvstore_for_path("s3://bucket/data.zarr", anonymous=True)
+        assert spec.get("aws_credentials") == {"type": "anonymous"}
+
+    def test_non_s3_schemes_unaffected(self, clean_aws_env):
+        from mesh_n_bone.util.zarr_io import kvstore_for_path
+        # gs: should never get aws_credentials regardless of env
+        spec, _ = kvstore_for_path("gs://bucket/data.zarr")
+        assert "aws_credentials" not in spec
+        # http: same
+        spec, _ = kvstore_for_path("https://example.com/data.zarr")
+        assert "aws_credentials" not in spec
+        # file: same
+        spec, _ = kvstore_for_path("/local/data.zarr")
+        assert "aws_credentials" not in spec


### PR DESCRIPTION
## Summary

- `kvstore_for_path` now injects `aws_credentials: {type: "anonymous"}` into the S3 spec when none of `AWS_ACCESS_KEY_ID`, `AWS_PROFILE`, or `AWS_ENDPOINT_URL` is set in the environment. This skips tensorstore's credential chain (IMDS → web-identity → profile), which times out ~2 s per provider on non-EC2 machines — ~7 s wasted per fresh OpenOrganelle / COSEM open.
- Auto-disabled when any of those three env vars is present (explicit credentials, picked profile, or moto/MinIO endpoint that needs auth) — existing moto tests keep passing because they already set `AWS_ACCESS_KEY_ID`.
- Explicit `anonymous=True/False` kwarg on `kvstore_for_path` for callers that want to override the heuristic.
- Bumps version to 0.6.0 (PR #40 already changed defaults; this is the first release including those changes plus this S3 fix).
- 6 new tests in `TestS3AnonymousCredentials` covering the heuristic; updated `test_precomputed_io::test_s3_url` to monkeypatch a clean env so the new behavior shows up.