### PR TITLE
Long scan for tmp_chunked for large number of segmented objects

### DIFF
--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -303,16 +303,63 @@ def _scan_one_assembly_mesh_dir(mesh_dir, mesh_id, amplification):
     )
 
 
-def _scan_assembly_mesh_estimates(dirname, amplification):
-    """Scan chunked mesh PLYs and estimate assembly memory per segment id."""
-    estimates = []
-    for mesh_id in sorted(os.listdir(dirname)):
-        mesh_dir = os.path.join(dirname, mesh_id)
-        if not os.path.isdir(mesh_dir):
-            continue
-        estimate = _scan_one_assembly_mesh_dir(mesh_dir, mesh_id, amplification)
-        if estimate is not None:
-            estimates.append(estimate)
+def _scan_assembly_mesh_estimates(dirname, amplification, num_workers=1):
+    """Scan chunked mesh PLYs and estimate assembly memory per segment id.
+
+    Parallelized with threads (I/O-bound directory listings + small PLY
+    header reads) and logs periodic progress, since this can iterate over
+    hundreds of thousands of segment directories on large datasets with no
+    other feedback before the assembly Dask cluster starts.
+    """
+    mesh_ids = [
+        mesh_id for mesh_id in sorted(os.listdir(dirname))
+        if os.path.isdir(os.path.join(dirname, mesh_id))
+    ]
+    total = len(mesh_ids)
+    if total == 0:
+        return []
+
+    done = 0
+    report_every = max(1, total // 20)
+
+    def _log_progress():
+        nonlocal done
+        done += 1
+        if done % report_every == 0 or done == total:
+            logger.info("Assembly scan: %d/%d chunked meshes scanned", done, total)
+
+    max_workers = max(1, int(num_workers))
+    if max_workers > 1 and total > max_workers:
+        from concurrent.futures import ThreadPoolExecutor
+        import threading
+
+        lock = threading.Lock()
+
+        def _log_progress_locked():
+            with lock:
+                _log_progress()
+
+        def _scan(mesh_id):
+            result = _scan_one_assembly_mesh_dir(
+                os.path.join(dirname, mesh_id), mesh_id, amplification,
+            )
+            _log_progress_locked()
+            return result
+
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            results = list(ex.map(_scan, mesh_ids))
+    else:
+        results = []
+        for mesh_id in mesh_ids:
+            results.append(
+                _scan_one_assembly_mesh_dir(
+                    os.path.join(dirname, mesh_id), mesh_id, amplification,
+                )
+            )
+            _log_progress()
+
+    estimates = [r for r in results if r is not None]
+    estimates.sort(key=lambda e: e.mesh_id)
     return estimates
 
 

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -1974,7 +1974,10 @@ class Meshify:
             check_mesh_validity=self.check_mesh_validity,
             has_custom_roi=self.has_custom_roi,
         )
-        estimates = _scan_assembly_mesh_estimates(dirname, amplification)
+        with Timing_Messager("Scanning chunked meshes for assembly planning", logger):
+            estimates = _scan_assembly_mesh_estimates(
+                dirname, amplification, num_workers=self.num_workers,
+            )
         if not estimates:
             logger.warning("No chunked mesh PLYs found in %s; skipping assembly.", dirname)
             shutil.rmtree(dirname, ignore_errors=True)

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -267,6 +267,42 @@ def _estimate_assembly_peak_bytes(
     return raw_mesh_bytes, int(baseline_bytes + amplification * effective_mesh_bytes)
 
 
+def _scan_one_assembly_mesh_dir(mesh_dir, mesh_id, amplification):
+    """Scan one segment's chunked PLYs and return its estimate, or ``None``."""
+    num_files = 0
+    ply_bytes = 0
+    vertex_count = 0
+    face_count = 0
+    for name in os.listdir(mesh_dir):
+        if not name.endswith(".ply"):
+            continue
+        num_files += 1
+        path = os.path.join(mesh_dir, name)
+        try:
+            ply_bytes += os.path.getsize(path)
+            vertices, faces = _read_ply_header_counts(path)
+        except (OSError, ValueError) as e:
+            logger.debug("Could not read PLY header for %s: %s", path, e)
+            continue
+        vertex_count += vertices
+        face_count += faces
+
+    if num_files == 0:
+        return None
+    raw_mesh_bytes, estimated_peak_bytes = _estimate_assembly_peak_bytes(
+        ply_bytes, vertex_count, face_count, amplification,
+    )
+    return AssemblyMeshEstimate(
+        mesh_id=str(mesh_id),
+        num_files=num_files,
+        ply_bytes=int(ply_bytes),
+        vertex_count=int(vertex_count),
+        face_count=int(face_count),
+        raw_mesh_bytes=int(raw_mesh_bytes),
+        estimated_peak_bytes=int(estimated_peak_bytes),
+    )
+
+
 def _scan_assembly_mesh_estimates(dirname, amplification):
     """Scan chunked mesh PLYs and estimate assembly memory per segment id."""
     estimates = []
@@ -274,41 +310,9 @@ def _scan_assembly_mesh_estimates(dirname, amplification):
         mesh_dir = os.path.join(dirname, mesh_id)
         if not os.path.isdir(mesh_dir):
             continue
-
-        num_files = 0
-        ply_bytes = 0
-        vertex_count = 0
-        face_count = 0
-        for name in os.listdir(mesh_dir):
-            if not name.endswith(".ply"):
-                continue
-            num_files += 1
-            path = os.path.join(mesh_dir, name)
-            try:
-                ply_bytes += os.path.getsize(path)
-                vertices, faces = _read_ply_header_counts(path)
-            except (OSError, ValueError) as e:
-                logger.debug("Could not read PLY header for %s: %s", path, e)
-                continue
-            vertex_count += vertices
-            face_count += faces
-
-        if num_files == 0:
-            continue
-        raw_mesh_bytes, estimated_peak_bytes = _estimate_assembly_peak_bytes(
-            ply_bytes, vertex_count, face_count, amplification,
-        )
-        estimates.append(
-            AssemblyMeshEstimate(
-                mesh_id=str(mesh_id),
-                num_files=num_files,
-                ply_bytes=int(ply_bytes),
-                vertex_count=int(vertex_count),
-                face_count=int(face_count),
-                raw_mesh_bytes=int(raw_mesh_bytes),
-                estimated_peak_bytes=int(estimated_peak_bytes),
-            )
-        )
+        estimate = _scan_one_assembly_mesh_dir(mesh_dir, mesh_id, amplification)
+        if estimate is not None:
+            estimates.append(estimate)
     return estimates
 
 

--- a/tests/test_meshify.py
+++ b/tests/test_meshify.py
@@ -167,6 +167,32 @@ class TestAssemblyMemoryPlanning:
         assert estimate.raw_mesh_bytes == 12 * 3 * 8 + 24 * 3 * 4
         assert estimate.estimated_peak_bytes > estimate.raw_mesh_bytes
 
+    @pytest.mark.parametrize(
+        "num_workers",
+        [
+            1,   # sequential path: max_workers > 1 is false
+            2,   # threaded path: total (10) > max_workers
+            32,  # more workers requested than mesh dirs exist: falls back to
+                 # sequential since total (10) > max_workers is false
+        ],
+    )
+    def test_scan_result_is_independent_of_num_workers(
+        self, tmp_output_dir, num_workers,
+    ):
+        from mesh_n_bone.meshify.meshify import _scan_assembly_mesh_estimates
+
+        tmp_chunked = os.path.join(tmp_output_dir, "tmp_chunked")
+        mesh_ids = [str(i) for i in range(10)]
+        for mesh_id in mesh_ids:
+            mesh_dir = os.path.join(tmp_chunked, mesh_id)
+            os.makedirs(mesh_dir)
+            self._write_binary_ply(os.path.join(mesh_dir, "block_0.ply"), 1, 1)
+
+        estimates = _scan_assembly_mesh_estimates(
+            tmp_chunked, amplification=16, num_workers=num_workers,
+        )
+        assert [e.mesh_id for e in estimates] == sorted(mesh_ids)
+
     def test_balanced_batches_leave_giant_mesh_alone(self):
         from mesh_n_bone.meshify.meshify import (
             AssemblyMeshEstimate,


### PR DESCRIPTION
## Summary
- Fix `meshify`'s pre-assembly step appearing to hang on segmentations with very large segment counts (e.g. a mitochondria dataset with 600k+ segments) — after "Generating chunked meshes" completes, the pipeline scans every `tmp_chunked/<mesh_id>/` directory to estimate per-segment memory before sizing the assembly Dask cluster, and this scan was single-threaded with zero progress output, making it indistinguishable from a hang.
- Extract the per-segment scan body into `_scan_one_assembly_mesh_dir`, then parallelize `_scan_assembly_mesh_estimates` across a `ThreadPoolExecutor` (I/O-bound: directory listings + small PLY header reads), falling back to the original sequential loop when there isn't enough work to bother.
- Add periodic `"N/M chunked meshes scanned"` progress logging, and wrap the whole scan in the existing `Timing_Messager` context manager used elsewhere in the pipeline.

## Test plan
- [x] `pixi run -e test pytest tests/test_meshify.py -q` — 47 passed
- [x] Added `test_scan_result_is_independent_of_num_workers`, parametrized over `num_workers=1` (sequential path), `2` (threaded path), and `32` (more workers than mesh dirs, falls back to sequential) — asserts identical results across all three
- [x] Verified `_scan_assembly_mesh_estimates` output is byte-identical to the pre-refactor version (confirmed via `git diff` between the reconstructed commit series and the original combined change)

