### PR TITLE
Add cascade downsampling and zarr v3 support for auto-built multires pyramids

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,17 +139,34 @@ use_existing_scales: true        # Set false to FORCE in-worker downsampling at 
                                  # (default: true)
 # When the input zarr exposes only s0 (no pre-built coarser levels),
 # the downsample multires strategy auto-builds the missing s_k arrays
-# into `{output_directory}/_intermediate_scales.zarr` in a single
-# parallel super-chunk pass over s0. Each LOD then reads from the
-# pre-built pyramid instead of repeatedly re-reading s0.
+# into `{output_directory}/_intermediate_scales.zarr`. This is automatic
+# and transparent — whenever a scale a LOD needs isn't already present
+# on the input, it gets built on the fly; no separate pre-processing
+# step is required.
 delete_intermediate_scales: true # Delete the auto-built `_intermediate_scales.zarr` once the
                                  # multires pipeline finishes. Set false to keep the pyramid
                                  # around for re-running with different mesh params on the same
                                  # data. (default: true)
-pyramid_alignment_mode: snap     # "snap" rounds an unaligned ROI INWARD to multiples of the
+# How the auto-built s_k arrays above are computed:
+#   false (default): every missing scale is downsampled directly from s0 by
+#     its cumulative factor — one parallel super-chunk pass, but per-task
+#     memory and total work both grow with num_lods.
+#   true: each missing scale is downsampled from the immediately coarser
+#     one (s_{k-1} -> s_k), chaining forward. ~O(source_size) total work
+#     instead of O(num_lods * source_size), and per-task memory stays
+#     bounded by a small step factor (~2x/axis) instead of growing with
+#     num_lods — prefer this for num_lods roughly 5-10+, or when direct
+#     downsampling runs out of memory. Manual choice only — it does not
+#     auto-switch based on memory pressure mid-run. Caveat: exact for
+#     associative reducers, an approximation (small mismatch at label
+#     boundaries) for the majority-vote reducers (mode, mode_suppress_zero,
+#     binary) — the same class of approximation most OME-NGFF pyramid
+#     generators already accept for label data.
+downsample_cascade: false        # (default: false)
+pyramid_alignment_mode: halo     # "snap" rounds an unaligned ROI INWARD to multiples of the
                                  # max per-axis factor (drops up to max_factor-1 voxels per edge);
                                  # "halo" rounds OUTWARD and reads beyond the ROI to complete the
-                                 # boundary cubes (no data loss). (default: snap)
+                                 # boundary cubes (no data loss). (default: halo)
 decimation_factor: 6             # Per-LOD face reduction factor. In decimate strategy: literal ratio
                                  # between LODs. In downsample strategy: target ratio used to derive
                                  # per-LOD target_reduction so the LOD-to-LOD face count drops by this

--- a/README.md
+++ b/README.md
@@ -142,7 +142,11 @@ use_existing_scales: true        # Set false to FORCE in-worker downsampling at 
 # into `{output_directory}/_intermediate_scales.zarr`. This is automatic
 # and transparent — whenever a scale a LOD needs isn't already present
 # on the input, it gets built on the fly; no separate pre-processing
-# step is required.
+# step is required. The pyramid is written in the SAME zarr format
+# (v2 or v3) as the input, and s0 is symlinked in (not copied) when the
+# formats match — so `_intermediate_scales.zarr` is directly browsable
+# as one consistent OME-NGFF group (e.g. in neuroglancer), not just
+# usable internally by mesh-n-bone.
 delete_intermediate_scales: true # Delete the auto-built `_intermediate_scales.zarr` once the
                                  # multires pipeline finishes. Set false to keep the pyramid
                                  # around for re-running with different mesh params on the same

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -516,21 +516,30 @@ def _existing_pyramid_scales(pyramid_path):
     """Return ``{lod_index: uniform_factor}`` of usable scales on disk, or
     ``None`` if the pyramid isn't readable.
 
-    Parses the OME-NGFF v0.4 multiscales metadata at
-    ``{pyramid_path}/.zattrs`` and returns the per-LOD uniform downsample
-    factor (relative to s0) for each dataset whose corresponding
-    ``s_k/.zarray`` actually exists on disk. Used to skip a fresh build
-    when a prior run already wrote the pyramid (e.g. debug re-runs).
+    Parses the OME-NGFF v0.4 multiscales metadata — from
+    ``{pyramid_path}/.zattrs`` (zarr v2) or ``{pyramid_path}/zarr.json``
+    (zarr v3, metadata under ``attributes``) — and returns the per-LOD
+    uniform downsample factor (relative to s0) for each dataset whose
+    corresponding array actually exists on disk (``s_k/.zarray`` for v2,
+    ``s_k/zarr.json`` for v3). Used to skip a fresh build when a prior
+    run already wrote the pyramid (e.g. debug re-runs).
 
-    Returns ``None`` when the file is missing, malformed, or doesn't
-    expose multiscales in the expected shape.
+    Returns ``None`` when neither metadata file is present/parseable, or
+    doesn't expose multiscales in the expected shape.
     """
     zattrs_path = os.path.join(pyramid_path, ".zattrs")
-    if not os.path.isfile(zattrs_path):
-        return None
+    zarr_json_path = os.path.join(pyramid_path, "zarr.json")
     try:
-        with open(zattrs_path) as f:
-            attrs = json.load(f)
+        if os.path.isfile(zattrs_path):
+            with open(zattrs_path) as f:
+                attrs = json.load(f)
+            array_metadata_name = ".zarray"
+        elif os.path.isfile(zarr_json_path):
+            with open(zarr_json_path) as f:
+                attrs = json.load(f).get("attributes", {})
+            array_metadata_name = "zarr.json"
+        else:
+            return None
         datasets = attrs["multiscales"][0]["datasets"]
         # s0's scale per-axis defines the base; s_k's factor = s_k/s_0
         s0_scale = None
@@ -563,7 +572,7 @@ def _existing_pyramid_scales(pyramid_path):
                 continue
             factor = int(round(factors[0]))
             # Verify the underlying zarr array actually exists
-            if not os.path.isfile(os.path.join(pyramid_path, name, ".zarray")):
+            if not os.path.isfile(os.path.join(pyramid_path, name, array_metadata_name)):
                 continue
             result[k] = factor
         return result
@@ -1150,6 +1159,7 @@ class Meshify:
         # Both N5 and neuroglancer precomputed store voxels in XYZ order
         # with no per-axis labels, so we need to swap to ZYX at read time.
         driver = _detect_zarr_driver(self._dataset_path)
+        self._driver = driver
         self._swap_axes = driver in ("n5", "neuroglancer_precomputed")
 
         # Get true (possibly non-integer) voxel size and offset from
@@ -2378,6 +2388,17 @@ class Meshify:
             )
         downsample_func = downsample_dispatch[self.downsample_method]
 
+        # Write the pyramid's own group metadata + s1+ arrays in the SAME
+        # zarr format as the real source, so s0 can be symlinked in
+        # without a version mismatch (see _try_symlink_s0's docstring —
+        # neuroglancer resolves the whole group by its declared format,
+        # and a symlinked-in array in a different format fails to open
+        # even though it's perfectly readable on its own). n5/precomputed
+        # sources can't be represented as a zarr array either way, so
+        # they fall back to the zarr v2 default (s0 just won't be
+        # symlinked in for those, same as before).
+        zarr_format = 3 if self._driver == "zarr3" else 2
+
         # Two decoupled sizes:
         #   out_chunk_shape:  on-disk chunk shape of the s_k zarr arrays.
         #                     Should be a SANE chunk size (~64-128) so
@@ -2525,6 +2546,7 @@ class Meshify:
                 "pyramid_path": pyramid_path,
                 "super_chunk_shape": tuple(int(v) for v in super_chunk_arr.tolist()),
                 "out_origin": tuple(int(v) for v in aligned_out_origin.tolist()),
+                "zarr_format": zarr_format,
             }
             return [(process_super_chunk_for_dask, sc_grid, worker_config, "pyramid (direct)")]
 
@@ -2560,6 +2582,7 @@ class Meshify:
                         "pyramid_path": pyramid_path,
                         "super_chunk_shape": tuple(int(v) for v in chunk_step.tolist()),
                         "out_origin": tuple(int(v) for v in aligned_out_origin.tolist()),
+                        "zarr_format": zarr_format,
                     }
                     label = f"s{k} (from s0, step={step})"
                 else:
@@ -2568,6 +2591,7 @@ class Meshify:
                         "read_path": os.path.join(pyramid_path, f"s{k - 1}"),
                         "write_path": os.path.join(pyramid_path, f"s{k}"),
                         "step_factor": list(step),
+                        "zarr_format": zarr_format,
                         "super_chunk_shape": tuple(int(v) for v in chunk_step.tolist()),
                         "downsample_method": self.downsample_method,
                     }
@@ -2638,6 +2662,7 @@ class Meshify:
                 s0_voxel_size_zyx=self.true_voxel_size.tolist(),
                 s0_translation_zyx=self.true_offset.tolist(),
                 s0_source_path=self._dataset_path,
+                zarr_format=zarr_format,
             )
 
             # Build adjusted dask config when processes/job has changed

--- a/src/mesh_n_bone/meshify/meshify.py
+++ b/src/mesh_n_bone/meshify/meshify.py
@@ -1022,7 +1022,43 @@ class Meshify:
         input via ``downsample_method`` instead — useful when the
         dataset's own downsampling is poor quality or you want
         consistent ``mode_suppress_zero`` behavior at every LOD that the
-        source's pre-built scales weren't built with.
+        source's pre-built scales weren't built with. Whenever a
+        required scale isn't found among the source's own pre-existing
+        levels, it's transparently auto-built under
+        ``{output_directory}/_intermediate_scales.zarr`` (see
+        ``delete_intermediate_scales``) — no separate pre-processing step
+        is needed.
+    downsample_cascade : bool
+        Controls HOW auto-built scales (above) are computed:
+
+        - ``False`` (default): every missing LOD is downsampled directly
+          from the finest available scale (``s0``, or whatever
+          ``input_path`` points at) by that LOD's cumulative factor. Each
+          LOD's per-chunk task re-reads the same source region at
+          ever-larger cumulative factors, so both peak memory per task
+          and total voxels processed scale with the *cumulative* factor
+          at each LOD — i.e. ``O(num_lods * source_size)`` total work.
+        - ``True``: each missing scale is instead downsampled from the
+          immediately coarser scale (``s_{k-1} -> s_k``), chaining
+          forward. Total work is ``~O(source_size)`` instead of
+          ``O(num_lods * source_size)``, and peak memory per task is
+          bounded by a small, constant step factor (~2x per axis)
+          instead of growing with ``num_lods``. Prefer this for large
+          ``num_lods`` (roughly 5-10+) or when direct downsampling runs
+          out of memory.
+
+        This is a manual, all-or-nothing choice for the run — it does
+        NOT auto-switch based on live memory pressure, which would mix
+        direct- and cascade-built scales (different provenance/quality)
+        within one pyramid.
+
+        Caveat: cascade composition is exact only for associative
+        reducers; for the majority-vote reducers (``downsample_method``
+        ``"mode"``, ``"mode_suppress_zero"``, or ``"binary"``),
+        mode-of-modes can differ from the true global mode at a small
+        fraction of label-boundary voxels. This is the same class of
+        approximation most OME-NGFF pyramid generators already accept
+        for label data.
     decimation_factor : int
         Per-LOD face-count reduction factor (default 6, hemibrain-matched).
         In the decimate strategy it's the literal ratio between
@@ -1082,6 +1118,7 @@ class Meshify:
         use_existing_scales: bool = True,
         delete_intermediate_scales: bool = True,
         pyramid_alignment_mode: str = "halo",
+        downsample_cascade: bool = False,
         decimation_factor: int = 6,
         decimation_aggressiveness: int = 7,
         delete_decimated_meshes: bool = True,
@@ -1259,6 +1296,7 @@ class Meshify:
         self.use_existing_scales = use_existing_scales
         self.delete_intermediate_scales = delete_intermediate_scales
         self.pyramid_alignment_mode = pyramid_alignment_mode
+        self.downsample_cascade = downsample_cascade
         self.decimation_factor = decimation_factor
         self.decimation_aggressiveness = decimation_aggressiveness
         self.delete_decimated_meshes = delete_decimated_meshes
@@ -2351,7 +2389,28 @@ class Meshify:
         #                     (so each task fills an integer number of
         #                     output chunks at every LOD). Sized to fit
         #                     per-worker memory budget.
-        max_factor = np.max(np.array([f for _, f in needed_uniform]), axis=0)
+        if self.downsample_cascade:
+            # Cascade: each missing level is built from the nearest
+            # predecessor we're ALSO building this run, resetting to real
+            # s0 whenever that predecessor is a gap (already present in
+            # `existing`, so we don't have a reader for its raw data here
+            # — see _build_cascade_passes). The largest per-axis factor
+            # any single task applies is therefore the largest STEP
+            # between consecutive missing levels, not the largest
+            # cumulative factor across every LOD — this is what keeps
+            # memory/compute bounded as num_lods grows.
+            cascade_steps = []
+            prev_k, prev_factor = None, (1, 1, 1)
+            for k, factor in needed_uniform:
+                read_from_s0 = not (prev_k is not None and k == prev_k + 1)
+                step = factor if read_from_s0 else tuple(
+                    int(a // b) for a, b in zip(factor, prev_factor)
+                )
+                cascade_steps.append((k, factor, step, read_from_s0))
+                prev_k, prev_factor = k, factor
+            max_factor = np.max(np.array([s for _, _, s, _ in cascade_steps]), axis=0)
+        else:
+            max_factor = np.max(np.array([f for _, f in needed_uniform]), axis=0)
         itemsize = int(np.dtype(seg_arr.data.dtype).itemsize)
         # 1.0 (s0 read) + 1/8 (LOD 1 output) + ~1/8 (downsample scratch)
         # plus ~1x slack for tensorstore decode/encode buffers, output-handle
@@ -2410,6 +2469,7 @@ class Meshify:
             align_roi_voxels,
             prepare_pyramid_metadata_and_arrays,
             process_super_chunk_for_dask,
+            process_cascade_chunk_for_dask,
         )
         max_factor_per_axis = max_factor  # alias
         factors_per_lod_full = per_lod_factors_for_anisotropy(
@@ -2431,12 +2491,94 @@ class Meshify:
             )
 
         logger.info(
-            "pyramid_builder: %d missing scale(s) detected for downsample "
-            "multires (factors=%s); building under %s with alignment_mode=%s",
+            "pyramid_builder: input exposes scales %s; auto-building %d "
+            "missing scale(s) %s under %s (alignment_mode=%s, strategy=%s)",
+            sorted(existing.keys()) or [1],
             len(needed_uniform),
             [factor for _, factor in needed_uniform],
             pyramid_path, self.pyramid_alignment_mode,
+            "cascade" if self.downsample_cascade else "direct-from-source",
         )
+
+        def _build_direct_pass():
+            super_chunk_arr = out_chunk_arr * max_factor
+            sc_grid = []
+            for z0 in range(int(aligned_out_origin[0]),
+                            int(aligned_out_origin[0] + aligned_out_shape[0]),
+                            int(super_chunk_arr[0])):
+                for y0 in range(int(aligned_out_origin[1]),
+                                int(aligned_out_origin[1] + aligned_out_shape[1]),
+                                int(super_chunk_arr[1])):
+                    for x0 in range(int(aligned_out_origin[2]),
+                                    int(aligned_out_origin[2] + aligned_out_shape[2]),
+                                    int(super_chunk_arr[2])):
+                        sc_grid.append((z0, y0, x0))
+            worker_config = {
+                "s0_dataset_path": dataset_path,
+                "dataset_offset": tuple(int(v) for v in seg_arr.roi.offset),
+                "voxel_size": tuple(int(v) for v in seg_arr.voxel_size),
+                "swap_axes": bool(swap_axes),
+                "dataset_shape": tuple(int(v) for v in dataset_shape.tolist()),
+                "factors_per_lod": [list(f) for f in factors_per_lod_full],
+                "missing_lods": [k for k, _ in needed_uniform],
+                "downsample_method": self.downsample_method,
+                "pyramid_path": pyramid_path,
+                "super_chunk_shape": tuple(int(v) for v in super_chunk_arr.tolist()),
+                "out_origin": tuple(int(v) for v in aligned_out_origin.tolist()),
+            }
+            return [(process_super_chunk_for_dask, sc_grid, worker_config, "pyramid (direct)")]
+
+        def _build_cascade_passes():
+            passes = []
+            prev_shape = None
+            for k, factor, step, read_from_s0 in cascade_steps:
+                step_arr = np.asarray(step, dtype=np.int64)
+                chunk_step = out_chunk_arr * step_arr
+
+                if read_from_s0:
+                    grid_origin, grid_shape = aligned_out_origin, aligned_out_shape
+                else:
+                    grid_origin, grid_shape = np.zeros(3, dtype=np.int64), prev_shape
+
+                sc_grid = []
+                for z0 in range(int(grid_origin[0]), int(grid_origin[0] + grid_shape[0]), int(chunk_step[0])):
+                    for y0 in range(int(grid_origin[1]), int(grid_origin[1] + grid_shape[1]), int(chunk_step[1])):
+                        for x0 in range(int(grid_origin[2]), int(grid_origin[2] + grid_shape[2]), int(chunk_step[2])):
+                            sc_grid.append((z0, y0, x0))
+
+                if read_from_s0:
+                    worker_func = process_super_chunk_for_dask
+                    worker_config = {
+                        "s0_dataset_path": dataset_path,
+                        "dataset_offset": tuple(int(v) for v in seg_arr.roi.offset),
+                        "voxel_size": tuple(int(v) for v in seg_arr.voxel_size),
+                        "swap_axes": bool(swap_axes),
+                        "dataset_shape": tuple(int(v) for v in dataset_shape.tolist()),
+                        "factors_per_lod": [[1, 1, 1]] * k + [list(step)],
+                        "missing_lods": [k],
+                        "downsample_method": self.downsample_method,
+                        "pyramid_path": pyramid_path,
+                        "super_chunk_shape": tuple(int(v) for v in chunk_step.tolist()),
+                        "out_origin": tuple(int(v) for v in aligned_out_origin.tolist()),
+                    }
+                    label = f"s{k} (from s0, step={step})"
+                else:
+                    worker_func = process_cascade_chunk_for_dask
+                    worker_config = {
+                        "read_path": os.path.join(pyramid_path, f"s{k - 1}"),
+                        "write_path": os.path.join(pyramid_path, f"s{k}"),
+                        "step_factor": list(step),
+                        "super_chunk_shape": tuple(int(v) for v in chunk_step.tolist()),
+                        "downsample_method": self.downsample_method,
+                    }
+                    label = f"s{k} (from s{k - 1}, step={step})"
+
+                passes.append((worker_func, sc_grid, worker_config, label))
+                f_arr = np.asarray(factor, dtype=np.int64)
+                prev_shape = ((aligned_out_shape + f_arr - 1) // f_arr).astype(np.int64)
+            return passes
+
+        passes = _build_cascade_passes() if self.downsample_cascade else _build_direct_pass()
 
         # Load dask config once. We use it to compute per-worker memory
         # budget (= job_memory / processes_per_job).
@@ -2498,34 +2640,6 @@ class Meshify:
                 s0_source_path=self._dataset_path,
             )
 
-            # Super-chunk grid (in s0 voxels)
-            sc_grid = []
-            for z0 in range(int(aligned_out_origin[0]),
-                            int(aligned_out_origin[0] + aligned_out_shape[0]),
-                            int(super_chunk_arr[0])):
-                for y0 in range(int(aligned_out_origin[1]),
-                                int(aligned_out_origin[1] + aligned_out_shape[1]),
-                                int(super_chunk_arr[1])):
-                    for x0 in range(int(aligned_out_origin[2]),
-                                    int(aligned_out_origin[2] + aligned_out_shape[2]),
-                                    int(super_chunk_arr[2])):
-                        sc_grid.append((z0, y0, x0))
-            n_chunks = len(sc_grid)
-
-            worker_config = {
-                "s0_dataset_path": dataset_path,
-                "dataset_offset": tuple(int(v) for v in seg_arr.roi.offset),
-                "voxel_size": tuple(int(v) for v in seg_arr.voxel_size),
-                "swap_axes": bool(swap_axes),
-                "dataset_shape": tuple(int(v) for v in dataset_shape.tolist()),
-                "factors_per_lod": [list(f) for f in factors_per_lod_full],
-                "missing_lods": [k for k, _ in needed_uniform],
-                "downsample_method": self.downsample_method,
-                "pyramid_path": pyramid_path,
-                "super_chunk_shape": tuple(int(v) for v in super_chunk_arr.tolist()),
-                "out_origin": tuple(int(v) for v in aligned_out_origin.tolist()),
-            }
-
             # Build adjusted dask config when processes/job has changed
             if base_dask_config and attempt_processes != base_processes:
                 adjusted_dask_config = _assembly_config_for_processes(
@@ -2552,27 +2666,33 @@ class Meshify:
             except (ImportError, ValueError, OSError) as _e:
                 logger.warning("pyramid_builder: could not adjust FD limit: %s", _e)
 
+            max_pass_chunks = max((len(g) for _, g, _, _ in passes), default=0)
+            total_pass_chunks = sum(len(g) for _, g, _, _ in passes)
             effective_workers = dask_util.effective_num_workers(
-                workers_with_adjusted, n_chunks, logger, "pyramid build",
+                workers_with_adjusted, max_pass_chunks, logger, "pyramid build",
             )
             logger.info(
                 "pyramid_builder: dispatching %d super-chunks across %d "
-                "dask workers", n_chunks, effective_workers,
+                "dask workers (%d pass(es): %s)", total_pass_chunks,
+                effective_workers, len(passes), [label for _, _, _, label in passes],
             )
 
             def _run(workers, dask_config):
                 import dask.bag as db
-                npartitions = dask_util.guesstimate_npartitions(n_chunks, workers)
-                bag = db.from_sequence(sc_grid, npartitions=npartitions).map(
-                    process_super_chunk_for_dask, worker_config=worker_config,
-                )
                 with dask_util.start_dask(
                     workers, "pyramid build", logger, config=dask_config,
                 ):
-                    with Timing_Messager(
-                        f"Building pyramid ({n_chunks} super-chunks)", logger,
-                    ):
-                        bag.compute()
+                    for worker_func, sc_grid, worker_config, label in passes:
+                        if not sc_grid:
+                            continue
+                        npartitions = dask_util.guesstimate_npartitions(len(sc_grid), workers)
+                        bag = db.from_sequence(sc_grid, npartitions=npartitions).map(
+                            worker_func, worker_config=worker_config,
+                        )
+                        with Timing_Messager(
+                            f"Building {label} ({len(sc_grid)} super-chunks)", logger,
+                        ):
+                            bag.compute()
 
             try:
                 dask_util.run_with_oom_retry(

--- a/src/mesh_n_bone/util/dask_util.py
+++ b/src/mesh_n_bone/util/dask_util.py
@@ -189,10 +189,6 @@ def start_dask(num_workers, msg, logger, config=None):
             logger,
         ):
             client = Client(cluster)
-            try:
-                client.wait_for_workers(num_workers, timeout=300)
-            except TimeoutError:
-                pass
 
         dashboard_link = client.cluster.dashboard_link
         if cluster_type == "local":

--- a/src/mesh_n_bone/util/pyramid_builder.py
+++ b/src/mesh_n_bone/util/pyramid_builder.py
@@ -384,6 +384,74 @@ def process_super_chunk_for_dask(sc_origin_tuple, worker_config):
     return None
 
 
+def process_cascade_chunk_for_dask(sc_origin_tuple, worker_config):
+    """Process ONE cascade super-chunk in a dask worker process.
+
+    Unlike ``process_super_chunk_for_dask`` (which always reads a
+    world-coordinate region of the *original* source array, with its own
+    offset/voxel-size/``swap_axes`` bookkeeping), this downsamples a single
+    per-axis ``step_factor`` from the immediately preceding pyramid level —
+    a plain, already ZYX-native zarr v2 array starting at voxel (0, 0, 0),
+    since it was written by this same pyramid builder.
+
+    Module-level so the function reference is picklable for dask.
+    """
+    from mesh_n_bone.meshify.downsample import (
+        downsample_labels_3d,
+        downsample_binary_3d,
+        downsample_labels_3d_suppress_zero,
+    )
+
+    dispatch = {
+        "mode": downsample_labels_3d,
+        "mode_suppress_zero": downsample_labels_3d_suppress_zero,
+        "binary": downsample_binary_3d,
+    }
+    downsample_func = dispatch[worker_config["downsample_method"]]
+
+    sc_origin = np.array(sc_origin_tuple, dtype=np.int64)
+    step = np.asarray(worker_config["step_factor"], dtype=np.int64)
+    chunk_step = np.asarray(worker_config["super_chunk_shape"], dtype=np.int64)
+
+    read_arr = _ts_handle_for_output(worker_config["read_path"])
+    read_shape = np.array(read_arr.shape, dtype=np.int64)
+    read_end = np.minimum(sc_origin + chunk_step, read_shape)
+    read_size = read_end - sc_origin
+    if np.any(read_size <= 0):
+        return None
+    z, y, x = sc_origin.tolist()
+    zE, yE, xE = read_end.tolist()
+    block = read_arr[z:zE, y:yE, x:xE].read().result()
+
+    trim = (np.array(block.shape) // step) * step
+    block = block[: trim[0], : trim[1], : trim[2]]
+    if block.size == 0:
+        return None
+    ds_block, _ = downsample_func(block, tuple(step.tolist()))
+
+    write_origin = sc_origin // step
+    out_arr = _ts_handle_for_output(worker_config["write_path"])
+    oz, oy, ox = write_origin.tolist()
+    arr_shape = out_arr.shape
+    ozE = min(oz + ds_block.shape[0], arr_shape[0])
+    oyE = min(oy + ds_block.shape[1], arr_shape[1])
+    oxE = min(ox + ds_block.shape[2], arr_shape[2])
+    out_arr[oz:ozE, oy:oyE, ox:oxE].write(
+        ds_block[: ozE - oz, : oyE - oy, : oxE - ox]
+    ).result()
+    del block, ds_block
+
+    import gc
+    gc.collect()
+    try:
+        import ctypes
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+    except (OSError, AttributeError):
+        pass
+
+    return None
+
+
 def prepare_pyramid_metadata_and_arrays(
     *,
     output_zarr_path,
@@ -457,6 +525,7 @@ def build_missing_pyramid_levels(
     s0_source_path: str | None = None,
     dispatch=None,
     num_workers: int = 1,
+    cascade: bool = False,
 ) -> str:
     """Build missing OME-NGFF pyramid levels and return the group path.
 
@@ -473,6 +542,22 @@ def build_missing_pyramid_levels(
     ``dispatch`` is an optional ``callable(func, args_iter) -> results``
     for parallelizing the super-chunk pass. If ``None``, the pass is
     sequential.
+
+    ``cascade``: when ``False`` (default), every missing level is
+    downsampled directly from s0 by its cumulative factor (as described
+    above). When ``True``, each missing level is instead downsampled from
+    the immediately preceding level ``s_{k-1}`` — but only when that
+    predecessor was ALSO just built by this call (i.e. ``k-1`` is missing
+    and directly precedes ``k``); if there's a gap (e.g. ``s_{k-1}`` was
+    already present in ``existing_factors``, so this driver has no reader
+    for its contents), the chain resets and that level is built directly
+    from s0 instead. This keeps peak per-task memory bounded by the
+    largest *step* between consecutive missing levels rather than the
+    largest *cumulative* factor — the win grows with ``num_lods``. Cascade
+    composition is exact for associative reducers (e.g. ``np.any``-based
+    binary downsampling) and an approximation for majority-vote reducers
+    (``mode``, ``mode_suppress_zero``, ``binary``): mode-of-modes can
+    differ from the true global mode at label-boundary voxels.
 
     Returns the path to the pyramid group.
     """
@@ -544,77 +629,148 @@ def build_missing_pyramid_levels(
     if s0_source_path is not None:
         _try_symlink_s0(output_zarr_path, s0_source_path)
 
-    # Super-chunk grid in s0 voxels
-    super_chunk_shape = out_chunk * max_factor
-    sc_grid = []
-    for z0 in range(int(out_origin[0]), int(out_origin[0] + out_shape[0]), int(super_chunk_shape[0])):
-        for y0 in range(int(out_origin[1]), int(out_origin[1] + out_shape[1]), int(super_chunk_shape[1])):
-            for x0 in range(int(out_origin[2]), int(out_origin[2] + out_shape[2]), int(super_chunk_shape[2])):
-                sc_grid.append(np.array([z0, y0, x0], dtype=np.int64))
+    def _run_chunk_grid(sc_grid, process_one, label):
+        n_chunks = len(sc_grid)
+        if n_chunks == 0:
+            return
+        if dispatch is not None:
+            dispatch(process_one, sc_grid)
+            return
+        if num_workers > 1 and n_chunks > 1:
+            from concurrent.futures import ThreadPoolExecutor
+            import threading
+            workers = min(num_workers, n_chunks)
+            logger.info(
+                "pyramid_builder: dispatching %d super-chunks across %d "
+                "threads (%s)", n_chunks, workers, label,
+            )
+            done = [0]
+            report_every = max(1, n_chunks // 20)
+            lock = threading.Lock()
 
-    def _process_super_chunk(sc_origin):
-        # Read range in s0 voxels — clip to dataset bounds for halo / dataset edge
-        read_end = np.minimum(sc_origin + super_chunk_shape, dataset_shape)
-        read_size = read_end - sc_origin
-        s0_block = s0_reader(sc_origin, read_size)
+            def _worker(sc):
+                process_one(sc)
+                with lock:
+                    done[0] += 1
+                    if done[0] % report_every == 0 or done[0] == n_chunks:
+                        logger.info(
+                            "pyramid_builder: %d/%d super-chunks done", done[0], n_chunks,
+                        )
 
-        def _write_one(k, ds_block, ds_origin):
-            if k not in out_arrays:
-                return
-            arr = out_arrays[k]
-            f = np.asarray(factors_per_lod[k], dtype=np.int64)
-            local_origin = ds_origin - (out_origin // f)
-            _write_zarr_v2_region(arr, local_origin, ds_block)
-
-        # Stream each LOD's output: compute → write → drop the buffer.
-        # Peak memory per task ≈ s0_block + one_lod_output.
-        downsample_super_chunk(
-            s0_block, sc_origin, factors_per_lod,
-            downsample_func, out_chunk,
-            write_chunk=_write_one,
-        )
-
-    n_chunks = len(sc_grid)
-    if dispatch is not None:
-        dispatch(_process_super_chunk, sc_grid)
-    elif num_workers > 1 and n_chunks > 1:
-        from concurrent.futures import ThreadPoolExecutor
-        import threading
-        workers = min(num_workers, n_chunks)
-        logger.info(
-            "pyramid_builder: dispatching %d super-chunks across %d threads "
-            "(super_chunk_shape=%s s0 voxels)",
-            n_chunks, workers, super_chunk_shape.tolist(),
-        )
-        done = [0]
-        report_every = max(1, n_chunks // 20)
-        lock = threading.Lock()
-
-        def _worker(sc):
-            _process_super_chunk(sc)
-            with lock:
-                done[0] += 1
-                if done[0] % report_every == 0 or done[0] == n_chunks:
+            with ThreadPoolExecutor(max_workers=workers) as ex:
+                list(ex.map(_worker, sc_grid))
+        else:
+            logger.info(
+                "pyramid_builder: processing %d super-chunks sequentially "
+                "(%s)", n_chunks, label,
+            )
+            report_every = max(1, n_chunks // 20)
+            for i, sc in enumerate(sc_grid):
+                process_one(sc)
+                done = i + 1
+                if done % report_every == 0 or done == n_chunks:
                     logger.info(
-                        "pyramid_builder: %d/%d super-chunks done", done[0], n_chunks,
+                        "pyramid_builder: %d/%d super-chunks done", done, n_chunks,
                     )
 
-        with ThreadPoolExecutor(max_workers=workers) as ex:
-            list(ex.map(_worker, sc_grid))
-    else:
-        logger.info(
-            "pyramid_builder: processing %d super-chunks sequentially "
-            "(super_chunk_shape=%s s0 voxels)",
-            n_chunks, super_chunk_shape.tolist(),
+    if not cascade:
+        # Direct: one super-chunk pass computes EVERY missing LOD from a
+        # single s0 read.
+        super_chunk_shape = out_chunk * max_factor
+        sc_grid = []
+        for z0 in range(int(out_origin[0]), int(out_origin[0] + out_shape[0]), int(super_chunk_shape[0])):
+            for y0 in range(int(out_origin[1]), int(out_origin[1] + out_shape[1]), int(super_chunk_shape[1])):
+                for x0 in range(int(out_origin[2]), int(out_origin[2] + out_shape[2]), int(super_chunk_shape[2])):
+                    sc_grid.append(np.array([z0, y0, x0], dtype=np.int64))
+
+        def _process_super_chunk(sc_origin):
+            read_end = np.minimum(sc_origin + super_chunk_shape, dataset_shape)
+            read_size = read_end - sc_origin
+            s0_block = s0_reader(sc_origin, read_size)
+
+            def _write_one(k, ds_block, ds_origin):
+                if k not in out_arrays:
+                    return
+                arr = out_arrays[k]
+                f = np.asarray(factors_per_lod[k], dtype=np.int64)
+                local_origin = ds_origin - (out_origin // f)
+                _write_zarr_v2_region(arr, local_origin, ds_block)
+
+            # Stream each LOD's output: compute → write → drop the buffer.
+            # Peak memory per task ≈ s0_block + one_lod_output.
+            downsample_super_chunk(
+                s0_block, sc_origin, factors_per_lod,
+                downsample_func, out_chunk,
+                write_chunk=_write_one,
+            )
+
+        _run_chunk_grid(
+            sc_grid, _process_super_chunk,
+            f"super_chunk_shape={super_chunk_shape.tolist()} s0 voxels",
         )
-        report_every = max(1, n_chunks // 20)
-        for i, sc in enumerate(sc_grid):
-            _process_super_chunk(sc)
-            done = i + 1
-            if done % report_every == 0 or done == n_chunks:
-                logger.info(
-                    "pyramid_builder: %d/%d super-chunks done", done, n_chunks,
+    else:
+        # Cascade: build missing levels sequentially, each from the
+        # nearest predecessor this call ALSO just built. A gap (the
+        # predecessor was already present in existing_factors, so we have
+        # no reader for it here) resets the chain to read s0 directly.
+        import zarr as _zarr
+
+        prev_k, prev_factor = None, (1, 1, 1)
+        for k, factor in missing:
+            read_from_s0 = not (prev_k is not None and k == prev_k + 1)
+            step = factor if read_from_s0 else tuple(
+                int(a // b) for a, b in zip(factor, prev_factor)
+            )
+            step_arr = np.asarray(step, dtype=np.int64)
+            chunk_step = out_chunk * step_arr
+            out_arr = out_arrays[k]
+
+            if read_from_s0:
+                grid_origin, grid_shape, bound_shape = out_origin, out_shape, dataset_shape
+                prev_arr = None
+            else:
+                grid_origin = np.zeros(3, dtype=np.int64)
+                prev_arr = _zarr.open_array(
+                    os.path.join(output_zarr_path, f"s{prev_k}"), mode="r",
                 )
+                grid_shape = np.asarray(prev_arr.shape, dtype=np.int64)
+                bound_shape = grid_shape
+
+            sc_grid = []
+            for z0 in range(int(grid_origin[0]), int(grid_origin[0] + grid_shape[0]), int(chunk_step[0])):
+                for y0 in range(int(grid_origin[1]), int(grid_origin[1] + grid_shape[1]), int(chunk_step[1])):
+                    for x0 in range(int(grid_origin[2]), int(grid_origin[2] + grid_shape[2]), int(chunk_step[2])):
+                        sc_grid.append(np.array([z0, y0, x0], dtype=np.int64))
+
+            def _process_cascade_chunk(sc_origin, chunk_step=chunk_step, bound_shape=bound_shape,
+                                        read_from_s0=read_from_s0, prev_arr=prev_arr,
+                                        step_arr=step_arr, out_origin_for_read=out_origin,
+                                        out_arr=out_arr):
+                read_end = np.minimum(sc_origin + chunk_step, bound_shape)
+                read_size = read_end - sc_origin
+                if np.any(read_size <= 0):
+                    return
+                if read_from_s0:
+                    block = s0_reader(sc_origin, read_size)
+                    write_origin = (sc_origin // step_arr) - (out_origin_for_read // step_arr)
+                else:
+                    z, y, x = sc_origin.tolist()
+                    zE, yE, xE = read_end.tolist()
+                    block = np.asarray(prev_arr[z:zE, y:yE, x:xE])
+                    write_origin = sc_origin // step_arr
+
+                trim = (np.array(block.shape) // step_arr) * step_arr
+                block = block[: trim[0], : trim[1], : trim[2]]
+                if block.size == 0:
+                    return
+                ds_block, _ = downsample_func(block, tuple(step_arr.tolist()))
+                _write_zarr_v2_region(out_arr, write_origin, ds_block)
+
+            _run_chunk_grid(
+                sc_grid, _process_cascade_chunk,
+                f"s{k} from {'s0' if read_from_s0 else f's{prev_k}'}, step={step}",
+            )
+            prev_k, prev_factor = k, factor
 
     logger.info(
         "pyramid_builder: built %d new scales at %s (factors=%s)",

--- a/src/mesh_n_bone/util/pyramid_builder.py
+++ b/src/mesh_n_bone/util/pyramid_builder.py
@@ -272,15 +272,20 @@ def _ts_handle_for_input(dataset_path):
     return handle
 
 
-def _ts_handle_for_output(path):
-    if path in _PYRAMID_WORKER_TS_CACHE:
-        return _PYRAMID_WORKER_TS_CACHE[path]
+def _ts_handle_for_output(path, zarr_format=2):
+    """Open a pyramid-owned zarr array (one we created, or the immediately
+    preceding cascade level, per this pyramid's own ``zarr_format``) for
+    read/write. Not for arbitrary external arrays — see
+    ``_ts_handle_for_input`` for those (driver auto-detected)."""
+    cache_key = (path, zarr_format)
+    if cache_key in _PYRAMID_WORKER_TS_CACHE:
+        return _PYRAMID_WORKER_TS_CACHE[cache_key]
     import tensorstore as ts
     from mesh_n_bone.util.image_data_interface import (
         _capped_tensorstore_context_spec,
     )
     handle = ts.open({
-        "driver": "zarr",
+        "driver": "zarr3" if zarr_format == 3 else "zarr",
         "kvstore": {"driver": "file", "path": path},
         "open": True,
         # Cap thread pools + disable decoded-chunk cache. Without this
@@ -288,7 +293,7 @@ def _ts_handle_for_output(path):
         # the worker's lifetime, OOMing on large super-chunk runs.
         "context": _capped_tensorstore_context_spec(),
     }).result()
-    _PYRAMID_WORKER_TS_CACHE[path] = handle
+    _PYRAMID_WORKER_TS_CACHE[cache_key] = handle
     return handle
 
 
@@ -356,7 +361,7 @@ def process_super_chunk_for_dask(sc_origin_tuple, worker_config):
         ds_origin = sc_origin // f
         local_origin = ds_origin - (out_origin // f)
         out_path = os.path.join(worker_config["pyramid_path"], f"s{k}")
-        out_arr = _ts_handle_for_output(out_path)
+        out_arr = _ts_handle_for_output(out_path, worker_config.get("zarr_format", 2))
         z, y, x = local_origin.tolist()
         arr_shape = out_arr.shape
         zE = min(z + ds_block.shape[0], arr_shape[0])
@@ -391,8 +396,9 @@ def process_cascade_chunk_for_dask(sc_origin_tuple, worker_config):
     world-coordinate region of the *original* source array, with its own
     offset/voxel-size/``swap_axes`` bookkeeping), this downsamples a single
     per-axis ``step_factor`` from the immediately preceding pyramid level —
-    a plain, already ZYX-native zarr v2 array starting at voxel (0, 0, 0),
-    since it was written by this same pyramid builder.
+    a plain, already ZYX-native array starting at voxel (0, 0, 0), in
+    whichever zarr format (``worker_config["zarr_format"]``) this whole
+    pyramid was written in, since it was written by this same builder.
 
     Module-level so the function reference is picklable for dask.
     """
@@ -412,8 +418,9 @@ def process_cascade_chunk_for_dask(sc_origin_tuple, worker_config):
     sc_origin = np.array(sc_origin_tuple, dtype=np.int64)
     step = np.asarray(worker_config["step_factor"], dtype=np.int64)
     chunk_step = np.asarray(worker_config["super_chunk_shape"], dtype=np.int64)
+    zarr_format = worker_config.get("zarr_format", 2)
 
-    read_arr = _ts_handle_for_output(worker_config["read_path"])
+    read_arr = _ts_handle_for_output(worker_config["read_path"], zarr_format)
     read_shape = np.array(read_arr.shape, dtype=np.int64)
     read_end = np.minimum(sc_origin + chunk_step, read_shape)
     read_size = read_end - sc_origin
@@ -430,7 +437,7 @@ def process_cascade_chunk_for_dask(sc_origin_tuple, worker_config):
     ds_block, _ = downsample_func(block, tuple(step.tolist()))
 
     write_origin = sc_origin // step
-    out_arr = _ts_handle_for_output(worker_config["write_path"])
+    out_arr = _ts_handle_for_output(worker_config["write_path"], zarr_format)
     oz, oy, ox = write_origin.tolist()
     arr_shape = out_arr.shape
     ozE = min(oz + ds_block.shape[0], arr_shape[0])
@@ -489,12 +496,13 @@ def prepare_pyramid_metadata_and_arrays(
         ds_path = os.path.join(output_zarr_path, f"s{k}")
         if os.path.exists(ds_path):
             shutil.rmtree(ds_path)
-        _create_zarr_v2_array(
+        _create_zarr_array(
             ds_path, shape=lod_shape, chunks=out_chunk.tolist(), dtype=dtype,
+            zarr_format=zarr_format,
         )
 
     if s0_source_path is not None:
-        _try_symlink_s0(output_zarr_path, s0_source_path)
+        _try_symlink_s0(output_zarr_path, s0_source_path, zarr_format=zarr_format)
 
     super_chunk_shape = out_chunk * max_factor
     return super_chunk_shape, max_factor
@@ -621,13 +629,14 @@ def build_missing_pyramid_levels(
         ds_path = os.path.join(output_zarr_path, f"s{k}")
         if os.path.exists(ds_path):
             shutil.rmtree(ds_path)
-        out_arrays[k] = _create_zarr_v2_array(
+        out_arrays[k] = _create_zarr_array(
             ds_path, shape=lod_shape, chunks=out_chunk.tolist(), dtype=dtype,
+            zarr_format=zarr_format,
         )
 
     # Optionally symlink s0
     if s0_source_path is not None:
-        _try_symlink_s0(output_zarr_path, s0_source_path)
+        _try_symlink_s0(output_zarr_path, s0_source_path, zarr_format=zarr_format)
 
     def _run_chunk_grid(sc_grid, process_one, label):
         n_chunks = len(sc_grid)
@@ -781,7 +790,7 @@ def build_missing_pyramid_levels(
 
 
 # ---------------------------------------------------------------------------
-# Minimal zarr v2 array helpers (no extra deps)
+# Minimal zarr v2/v3 array helpers (no extra deps)
 # ---------------------------------------------------------------------------
 
 
@@ -798,45 +807,90 @@ _TS_DTYPE_MAP = {
     np.dtype("float64"): "<f8",
 }
 
+# zarr v3's core spec names data types after their plain numpy names
+# (no byte-order/size prefix like v2's "<u2").
+_TS_V3_DTYPE_MAP = {
+    np.dtype("uint8"): "uint8",
+    np.dtype("uint16"): "uint16",
+    np.dtype("uint32"): "uint32",
+    np.dtype("uint64"): "uint64",
+    np.dtype("int8"): "int8",
+    np.dtype("int16"): "int16",
+    np.dtype("int32"): "int32",
+    np.dtype("int64"): "int64",
+    np.dtype("float32"): "float32",
+    np.dtype("float64"): "float64",
+}
 
-def _create_zarr_v2_array(path, shape, chunks, dtype):
-    """Create a zarr v2 array on disk via tensorstore and return a handle.
+
+def _create_zarr_array(path, shape, chunks, dtype, zarr_format=2):
+    """Create a zarr array on disk via tensorstore and return a handle.
 
     Uses tensorstore (already a core dep) instead of the optional ``zarr``
     package so the pyramid builder works in any pixi env that has the
-    base mesh-n-bone install.
+    base mesh-n-bone install. ``zarr_format`` (2 or 3) should match
+    whatever format this whole pyramid is being written in — see
+    ``_try_symlink_s0`` for why that matters.
     """
     import tensorstore as ts
     if os.path.exists(path):
         shutil.rmtree(path)
     dt = np.dtype(dtype)
-    ts_dtype = _TS_DTYPE_MAP.get(dt)
-    if ts_dtype is None:
-        raise ValueError(
-            f"Unsupported dtype for pyramid build: {dt}. "
-            f"Add it to _TS_DTYPE_MAP."
-        )
-    spec = {
-        "driver": "zarr",  # zarr v2
-        "kvstore": {"driver": "file", "path": path},
-        "metadata": {
-            "shape": list(shape),
-            "chunks": list(chunks),
-            "dtype": ts_dtype,
-            "compressor": None,
-            "fill_value": 0,
-            "order": "C",
-        },
-        "create": True,
-        "delete_existing": True,
-    }
+    if zarr_format == 3:
+        ts_dtype = _TS_V3_DTYPE_MAP.get(dt)
+        if ts_dtype is None:
+            raise ValueError(
+                f"Unsupported dtype for pyramid build: {dt}. "
+                f"Add it to _TS_V3_DTYPE_MAP."
+            )
+        spec = {
+            "driver": "zarr3",
+            "kvstore": {"driver": "file", "path": path},
+            "metadata": {
+                "shape": list(shape),
+                "data_type": ts_dtype,
+                "chunk_grid": {
+                    "name": "regular",
+                    "configuration": {"chunk_shape": list(chunks)},
+                },
+                # Uncompressed, matching the v2 branch's "compressor": None
+                # — mode/label downsamples are CPU- not I/O-bound here.
+                "codecs": [{"name": "bytes"}],
+                "fill_value": 0,
+            },
+            "create": True,
+            "delete_existing": True,
+        }
+    else:
+        ts_dtype = _TS_DTYPE_MAP.get(dt)
+        if ts_dtype is None:
+            raise ValueError(
+                f"Unsupported dtype for pyramid build: {dt}. "
+                f"Add it to _TS_DTYPE_MAP."
+            )
+        spec = {
+            "driver": "zarr",  # zarr v2
+            "kvstore": {"driver": "file", "path": path},
+            "metadata": {
+                "shape": list(shape),
+                "chunks": list(chunks),
+                "dtype": ts_dtype,
+                "compressor": None,
+                "fill_value": 0,
+                "order": "C",
+            },
+            "create": True,
+            "delete_existing": True,
+        }
     return ts.open(spec).result()
 
 
 def _write_zarr_v2_region(arr, origin_voxels, data):
     """Write ``data`` into ``arr`` at the given origin (zyx voxel coords).
 
-    ``arr`` is a tensorstore handle from ``_create_zarr_v2_array``.
+    ``arr`` is a tensorstore handle from ``_create_zarr_array`` — despite
+    the name (kept for backwards compatibility), this write path is
+    format-agnostic; it works the same for v2 or v3 handles.
     """
     z, y, x = origin_voxels.tolist()
     shape = arr.shape
@@ -848,15 +902,55 @@ def _write_zarr_v2_region(arr, origin_voxels, data):
     arr[z:zE, y:yE, x:xE].write(clipped).result()
 
 
-def _try_symlink_s0(pyramid_path, s0_source_path):
+def _try_symlink_s0(pyramid_path, s0_source_path, zarr_format=2):
     """Symlink the pyramid's s0 to the source s0 array.
 
     Returns True on success. Logs a warning and returns False otherwise
-    (e.g. cross-filesystem, remote source, permission denied).
+    (e.g. cross-filesystem, remote source, permission denied, or a zarr
+    format mismatch — see below).
     """
     target = os.path.join(pyramid_path, "s0")
     if os.path.exists(target):
         return True
+
+    # This pyramid's own group metadata (.zgroup/.zattrs or zarr.json) and
+    # its s1+ arrays are always written in ``zarr_format`` (see
+    # _create_zarr_array). If the real source array is in a DIFFERENT
+    # format, symlinking it in as s0 produces a group that LOOKS complete
+    # but is format-inconsistent: generic OME-zarr multiscale readers
+    # (e.g. neuroglancer) resolve the group's declared format and then
+    # look for THAT format's array metadata inside s0 — which has the
+    # other format's metadata file instead — and fail with something like
+    # "zarr v{version} array metadata not found", even though s0 is
+    # perfectly readable on its own (e.g. with an explicit driver
+    # override). s1+ are unaffected since those really do match.
+    # Leave s0 absent rather than link in something unreadable through
+    # the group's declared format — mesh-n-bone's own LOD-reading logic
+    # never depends on this symlink anyway (LOD 0 always reads the real
+    # source path directly); it's a convenience for external tools only.
+    # (Callers should normally have already matched ``zarr_format`` to
+    # the source's own format — see Meshify._build_missing_pyramid_scales
+    # — so this is mostly a safety net for n5/precomputed sources, which
+    # can't be represented as a zarr array at all.)
+    expected_driver = "zarr3" if zarr_format == 3 else "zarr"
+    try:
+        from mesh_n_bone.util.image_data_interface import _detect_zarr_driver
+        actual_driver = _detect_zarr_driver(s0_source_path)
+        if actual_driver != expected_driver:
+            logger.warning(
+                "pyramid_builder: not symlinking s0 from %s into %s — "
+                "source format (%s) doesn't match this pyramid's "
+                "zarr_format=%d (%s). s0 stays absent from the pyramid; "
+                "it's still directly browsable at its own real path/URL.",
+                s0_source_path, target, actual_driver, zarr_format, expected_driver,
+            )
+            return False
+    except Exception as e:
+        logger.warning(
+            "pyramid_builder: could not detect zarr format of %s (%s); "
+            "proceeding with symlink attempt.", s0_source_path, e,
+        )
+
     try:
         os.symlink(s0_source_path, target)
         return True

--- a/tests/test_integration_meshify.py
+++ b/tests/test_integration_meshify.py
@@ -570,7 +570,13 @@ class TestMeshifyDownsampleAutoBuildPyramid:
     def test_auto_builds_pyramid_via_cascade_for_single_scale_input(self, tmp_output_dir):
         """Same auto-build path as test_auto_builds_pyramid_for_single_scale_input,
         but with downsample_cascade=True — s1 is built from s0 and s2 is
-        built from s1 (rather than both directly from s0)."""
+        built from s1 (rather than both directly from s0).
+
+        This fixture's source is zarr v3, so the pyramid's own arrays and
+        s0 symlink must also be v3 (see Meshify._build_missing_pyramid_scales's
+        zarr_format detection) — a v2 pyramid here would silently fail to
+        symlink s0 (format mismatch) and even fail to CREATE s1/s2 the way
+        this test reads them back."""
         s0_path, _ = self._create_single_scale_ome_zarr(tmp_output_dir)
         output_dir = os.path.join(tmp_output_dir, "out_autobuild_cascade")
         m = Meshify(
@@ -595,6 +601,12 @@ class TestMeshifyDownsampleAutoBuildPyramid:
             assert os.path.isdir(os.path.join(pyramid_root, f"s{k}")), (
                 f"Expected pyramid s{k} array on disk"
             )
+        # s0 IS symlinked in this time: source is zarr v3 and so is the
+        # pyramid (format-matched), unlike the v2-pyramid-vs-v3-source
+        # mismatch this whole feature exists to avoid.
+        s0_link = os.path.join(pyramid_root, "s0")
+        assert os.path.islink(s0_link)
+        assert os.path.isfile(os.path.join(s0_link, "zarr.json"))
 
         import tensorstore as ts
         from mesh_n_bone.meshify.downsample import downsample_labels_3d
@@ -603,11 +615,11 @@ class TestMeshifyDownsampleAutoBuildPyramid:
             "open": True,
         }).result().read().result()
         s1 = ts.open({
-            "driver": "zarr", "kvstore": {"driver": "file",
+            "driver": "zarr3", "kvstore": {"driver": "file",
             "path": os.path.join(pyramid_root, "s1")}, "open": True,
         }).result().read().result()
         s2 = ts.open({
-            "driver": "zarr", "kvstore": {"driver": "file",
+            "driver": "zarr3", "kvstore": {"driver": "file",
             "path": os.path.join(pyramid_root, "s2")}, "open": True,
         }).result().read().result()
         ref_s1, _ = downsample_labels_3d(s0_arr, (2, 2, 2))

--- a/tests/test_integration_meshify.py
+++ b/tests/test_integration_meshify.py
@@ -567,6 +567,61 @@ class TestMeshifyDownsampleAutoBuildPyramid:
             )
             assert "_intermediate_scales.zarr" in calls[k]["input_dataset_path"]
 
+    def test_auto_builds_pyramid_via_cascade_for_single_scale_input(self, tmp_output_dir):
+        """Same auto-build path as test_auto_builds_pyramid_for_single_scale_input,
+        but with downsample_cascade=True — s1 is built from s0 and s2 is
+        built from s1 (rather than both directly from s0)."""
+        s0_path, _ = self._create_single_scale_ome_zarr(tmp_output_dir)
+        output_dir = os.path.join(tmp_output_dir, "out_autobuild_cascade")
+        m = Meshify(
+            input_path=s0_path,
+            output_directory=output_dir,
+            num_workers=1,
+            do_multires=True,
+            num_lods=3,
+            multires_strategy="downsample",
+            downsample_cascade=True,
+            delete_intermediate_scales=False,  # keep for inspection
+            target_faces_per_lod0_chunk=200,
+            check_mesh_validity=False,
+            do_analysis=False,
+            do_simplification=True,
+        )
+        m.get_meshes()
+
+        pyramid_root = os.path.join(output_dir, "_intermediate_scales.zarr")
+        assert os.path.isdir(pyramid_root)
+        for k in (1, 2):
+            assert os.path.isdir(os.path.join(pyramid_root, f"s{k}")), (
+                f"Expected pyramid s{k} array on disk"
+            )
+
+        import tensorstore as ts
+        from mesh_n_bone.meshify.downsample import downsample_labels_3d
+        s0_arr = ts.open({
+            "driver": "zarr3", "kvstore": {"driver": "file", "path": s0_path},
+            "open": True,
+        }).result().read().result()
+        s1 = ts.open({
+            "driver": "zarr", "kvstore": {"driver": "file",
+            "path": os.path.join(pyramid_root, "s1")}, "open": True,
+        }).result().read().result()
+        s2 = ts.open({
+            "driver": "zarr", "kvstore": {"driver": "file",
+            "path": os.path.join(pyramid_root, "s2")}, "open": True,
+        }).result().read().result()
+        ref_s1, _ = downsample_labels_3d(s0_arr, (2, 2, 2))
+        ref_s2, _ = downsample_labels_3d(s0_arr, (4, 4, 4))
+        # s1 is a single step (nothing composed yet) — matches exactly.
+        np.testing.assert_array_equal(s1, ref_s1)
+        # s2 is built from s1 (cascade) rather than s0 (direct): mode-of-modes
+        # is not associative, so a small mismatch at the sphere's boundary
+        # voxels vs. the global/direct reference is expected (the documented
+        # cascade + mode-reducer approximation) — assert high agreement
+        # rather than exact equality.
+        agreement = np.mean(np.asarray(s2) == ref_s2)
+        assert agreement > 0.95, f"expected high agreement, got {agreement:.2%}"
+
     def test_delete_intermediate_scales_default_cleans_up(self, tmp_output_dir):
         s0_path, _ = self._create_single_scale_ome_zarr(tmp_output_dir)
         output_dir = os.path.join(tmp_output_dir, "out_autobuild_cleanup")

--- a/tests/test_integration_multiscale.py
+++ b/tests/test_integration_multiscale.py
@@ -91,6 +91,29 @@ class TestDownsampleStrategy:
             ply_files = [f for f in os.listdir(scale_dir) if f.endswith(".ply")]
             assert len(ply_files) > 0
 
+    def test_downsample_cascade_generates_lod_directories(self, zarr_segmentation, tmp_output_dir):
+        """downsample_cascade=True should produce the same valid LOD
+        directory structure as the direct (default) strategy — this
+        exercises the full Meshify -> _build_missing_pyramid_scales ->
+        cascade auto-build path end-to-end (the fixture's input is
+        single-scale, so every LOD beyond 0 must be auto-built)."""
+        from mesh_n_bone.meshify.meshify import Meshify
+
+        output_dir = os.path.join(tmp_output_dir, "ds_cascade")
+        meshify = Meshify(
+            input_path=zarr_segmentation, output_directory=output_dir,
+            do_multires=True, num_lods=3, multires_strategy="downsample",
+            delete_decimated_meshes=False, downsample_cascade=True, **_BASE_KWARGS,
+        )
+        meshify.get_meshes()
+
+        mesh_lods_dir = os.path.join(output_dir, "mesh_lods")
+        for lod in range(3):
+            scale_dir = os.path.join(mesh_lods_dir, f"s{lod}")
+            assert os.path.isdir(scale_dir), f"s{lod} directory should exist"
+            ply_files = [f for f in os.listdir(scale_dir) if f.endswith(".ply")]
+            assert len(ply_files) > 0, f"s{lod} should contain PLY files"
+
     def test_downsample_with_simplification_face_count_monotonic(
         self, zarr_segmentation, tmp_output_dir
     ):

--- a/tests/test_pyramid_builder.py
+++ b/tests/test_pyramid_builder.py
@@ -743,3 +743,43 @@ class TestUnalignedRoiSnap:
         # Compare to global downsample of the snapped region
         ref_s1, _ = downsample_labels_3d(vol[4:36, 4:36, 4:36], (2, 2, 2))
         np.testing.assert_array_equal(s1[:], ref_s1)
+
+
+class TestExistingPyramidScalesBothFormats:
+    """``_existing_pyramid_scales`` (the "reuse a prior run's pyramid"
+    shortcut) must parse group metadata from EITHER a zarr v2 pyramid
+    (.zattrs) or a zarr v3 one (zarr.json, attributes nested under
+    "attributes") — otherwise a v3-formatted pyramid (built once the
+    source's own format is matched) would silently never be recognized
+    for reuse on a second run, always rebuilding from scratch."""
+
+    def _build(self, tmp_path, zarr_format):
+        from mesh_n_bone.meshify.meshify import _existing_pyramid_scales
+
+        rng = np.random.default_rng(1)
+        vol = rng.integers(low=0, high=4, size=(16, 16, 16), dtype=np.uint8)
+        out_path = str(tmp_path / f"pyramid_v{zarr_format}.zarr")
+        build_missing_pyramid_levels(
+            s0_reader=lambda o, s: vol[o[0]:o[0]+s[0], o[1]:o[1]+s[1], o[2]:o[2]+s[2]].copy(),
+            s0_dataset_shape_voxels=np.array(vol.shape),
+            s0_voxel_size_zyx=[1.0, 1.0, 1.0],
+            s0_translation_zyx=[0.5, 0.5, 0.5],
+            dtype=vol.dtype,
+            num_lods=3,
+            existing_factors=set(),
+            output_zarr_path=out_path,
+            downsample_func=downsample_labels_3d,
+            out_chunk_shape_voxels=(4, 4, 4),
+            zarr_format=zarr_format,
+        )
+        return out_path, _existing_pyramid_scales(out_path)
+
+    def test_parses_zarr_v2_pyramid(self, tmp_path):
+        out_path, result = self._build(tmp_path, zarr_format=2)
+        assert os.path.isfile(os.path.join(out_path, ".zattrs"))
+        assert result == {1: 2, 2: 4}
+
+    def test_parses_zarr_v3_pyramid(self, tmp_path):
+        out_path, result = self._build(tmp_path, zarr_format=3)
+        assert os.path.isfile(os.path.join(out_path, "zarr.json"))
+        assert result == {1: 2, 2: 4}

--- a/tests/test_pyramid_builder.py
+++ b/tests/test_pyramid_builder.py
@@ -310,6 +310,99 @@ class TestEndToEndPyramidBuild:
         assert os.path.islink(s0_link)
         assert os.path.exists(os.path.join(s0_link, "marker.txt"))
 
+    def test_no_symlink_when_source_is_zarr_v3(self, tmp_path):
+        """This pyramid's own group metadata and its s1+ arrays are
+        written in whatever ``zarr_format`` the caller asks for
+        (default 2). A zarr v3 source symlinked in as s0 when the
+        pyramid is v2 (the default) would be format-inconsistent —
+        generic OME-zarr readers (e.g. neuroglancer) resolve the group
+        by its declared format then fail to find matching metadata
+        inside the differently-formatted s0 array. s0 must stay absent
+        instead (see test_symlinks_when_zarr_format_matches_source for
+        the case where the caller matches the format up front)."""
+        s0_src = tmp_path / "source_s0"
+        s0_src.mkdir()
+        (s0_src / "zarr.json").write_text('{"zarr_format": 3, "node_type": "array"}')
+
+        rng = np.random.default_rng(0)
+        vol = rng.integers(low=0, high=2, size=(16, 16, 16), dtype=np.uint8)
+
+        out_path = str(tmp_path / "pyramid.zarr")
+        build_missing_pyramid_levels(
+            s0_reader=lambda o, s: vol[o[0]:o[0]+s[0], o[1]:o[1]+s[1], o[2]:o[2]+s[2]].copy(),
+            s0_dataset_shape_voxels=np.array(vol.shape),
+            s0_voxel_size_zyx=[1.0, 1.0, 1.0],
+            s0_translation_zyx=[0.5, 0.5, 0.5],
+            dtype=vol.dtype,
+            num_lods=2,
+            existing_factors=set(),
+            output_zarr_path=out_path,
+            downsample_func=downsample_labels_3d,
+            out_chunk_shape_voxels=(4, 4, 4),
+            s0_source_path=str(s0_src),
+            # zarr_format defaults to 2 — mismatched against the v3 source above.
+        )
+
+        s0_link = os.path.join(out_path, "s0")
+        assert not os.path.exists(s0_link)
+        assert not os.path.islink(s0_link)
+        # s1 (a genuine v2 array this builder wrote) is unaffected.
+        assert os.path.isdir(os.path.join(out_path, "s1"))
+
+    def test_symlinks_when_zarr_format_matches_source(self, tmp_path):
+        """When the caller matches zarr_format to the source's real
+        format (zarr v3 here), s0 CAN be symlinked in safely, and s1/s2
+        are themselves real, readable v3 arrays — the whole point of
+        detecting the source format up front (Meshify does this via
+        self._driver) instead of always hardcoding v2."""
+        import tensorstore as ts
+
+        rng = np.random.default_rng(0)
+        vol = rng.integers(low=0, high=4, size=(16, 16, 16), dtype=np.uint8)
+        s0_src = tmp_path / "source_s0"
+        ts.open({
+            "driver": "zarr3",
+            "kvstore": {"driver": "file", "path": str(s0_src)},
+            "metadata": {
+                "shape": list(vol.shape),
+                "data_type": "uint8",
+                "chunk_grid": {"name": "regular",
+                               "configuration": {"chunk_shape": [4, 4, 4]}},
+            },
+            "create": True, "delete_existing": True,
+        }).result().write(vol).result()
+
+        out_path = str(tmp_path / "pyramid.zarr")
+        build_missing_pyramid_levels(
+            s0_reader=lambda o, s: vol[o[0]:o[0]+s[0], o[1]:o[1]+s[1], o[2]:o[2]+s[2]].copy(),
+            s0_dataset_shape_voxels=np.array(vol.shape),
+            s0_voxel_size_zyx=[1.0, 1.0, 1.0],
+            s0_translation_zyx=[0.5, 0.5, 0.5],
+            dtype=vol.dtype,
+            num_lods=3,
+            existing_factors=set(),
+            output_zarr_path=out_path,
+            downsample_func=downsample_labels_3d,
+            out_chunk_shape_voxels=(4, 4, 4),
+            s0_source_path=str(s0_src),
+            zarr_format=3,
+        )
+
+        s0_link = os.path.join(out_path, "s0")
+        assert os.path.islink(s0_link)
+        assert os.path.isfile(os.path.join(s0_link, "zarr.json"))
+        # Group metadata is zarr.json (v3), not .zattrs/.zgroup (v2).
+        assert os.path.isfile(os.path.join(out_path, "zarr.json"))
+        assert not os.path.exists(os.path.join(out_path, ".zattrs"))
+
+        s1 = ts.open({
+            "driver": "zarr3",
+            "kvstore": {"driver": "file", "path": os.path.join(out_path, "s1")},
+            "open": True,
+        }).result().read().result()
+        ref_s1, _ = downsample_labels_3d(vol, (2, 2, 2))
+        np.testing.assert_array_equal(s1, ref_s1)
+
     def test_existing_factor_skipped(self, tmp_path):
         """If a factor is already present (existing_factors), it shouldn't
         be re-built."""

--- a/tests/test_pyramid_builder.py
+++ b/tests/test_pyramid_builder.py
@@ -14,7 +14,10 @@ import os
 import numpy as np
 import pytest
 
-from mesh_n_bone.meshify.downsample import downsample_labels_3d
+from mesh_n_bone.meshify.downsample import (
+    downsample_labels_3d,
+    downsample_binary_3d_suppress_zero,
+)
 from mesh_n_bone.util.pyramid_builder import (
     align_roi_voxels,
     build_missing_pyramid_levels,
@@ -329,6 +332,111 @@ class TestEndToEndPyramidBuild:
         # s1 should NOT have been written, but s2 should
         assert not os.path.isdir(os.path.join(out_path, "s1"))
         assert os.path.isdir(os.path.join(out_path, "s2"))
+
+
+class TestCascadeDownsampling:
+    """``cascade=True`` builds each missing level from the immediately
+    preceding one instead of always downsampling straight from s0."""
+
+    def test_cascade_matches_direct_for_associative_reducer(self, tmp_path):
+        """np.any-based downsampling is associative — cascade (s1 then
+        s2-from-s1) must match direct (s2-from-s0) bit-for-bit."""
+        rng = np.random.default_rng(3)
+        vol = rng.integers(low=0, high=2, size=(32, 32, 32), dtype=np.uint8)
+
+        def reader(o, s):
+            return vol[o[0]:o[0]+s[0], o[1]:o[1]+s[1], o[2]:o[2]+s[2]].copy()
+
+        common = dict(
+            s0_reader=reader,
+            s0_dataset_shape_voxels=np.array(vol.shape),
+            s0_voxel_size_zyx=[1.0, 1.0, 1.0],
+            s0_translation_zyx=[0.5, 0.5, 0.5],
+            dtype=vol.dtype,
+            num_lods=3,
+            existing_factors=set(),
+            downsample_func=downsample_binary_3d_suppress_zero,
+            out_chunk_shape_voxels=(4, 4, 4),
+        )
+        direct_path = str(tmp_path / "direct.zarr")
+        cascade_path = str(tmp_path / "cascade.zarr")
+        build_missing_pyramid_levels(output_zarr_path=direct_path, cascade=False, **common)
+        build_missing_pyramid_levels(output_zarr_path=cascade_path, cascade=True, **common)
+
+        import zarr
+        for lvl in ("s1", "s2"):
+            direct_arr = zarr.open_array(os.path.join(direct_path, lvl), mode="r")[:]
+            cascade_arr = zarr.open_array(os.path.join(cascade_path, lvl), mode="r")[:]
+            np.testing.assert_array_equal(direct_arr, cascade_arr)
+
+    def test_cascade_approximates_mode_reducer(self, tmp_path):
+        """Mode (majority-vote) downsampling is NOT associative — s1
+        (a single step, nothing composed yet) still matches exactly, but
+        s2 (mode-of-modes under cascade) is only a close approximation of
+        the direct/global reference. Uses a block-structured label volume
+        (contiguous 4-voxel regions) since that's representative of real
+        segmentation data — per-voxel random labels disagree almost
+        everywhere and wouldn't demonstrate the "small fraction of
+        boundary voxels" caveat this test documents."""
+        rng = np.random.default_rng(11)
+        coarse = rng.integers(low=0, high=6, size=(8, 8, 8), dtype=np.uint8)
+        vol = np.kron(coarse, np.ones((4, 4, 4), dtype=np.uint8))
+
+        def reader(o, s):
+            return vol[o[0]:o[0]+s[0], o[1]:o[1]+s[1], o[2]:o[2]+s[2]].copy()
+
+        common = dict(
+            s0_reader=reader,
+            s0_dataset_shape_voxels=np.array(vol.shape),
+            s0_voxel_size_zyx=[1.0, 1.0, 1.0],
+            s0_translation_zyx=[0.5, 0.5, 0.5],
+            dtype=vol.dtype,
+            num_lods=3,
+            existing_factors=set(),
+            downsample_func=downsample_labels_3d,
+            out_chunk_shape_voxels=(4, 4, 4),
+        )
+        direct_path = str(tmp_path / "direct.zarr")
+        cascade_path = str(tmp_path / "cascade.zarr")
+        build_missing_pyramid_levels(output_zarr_path=direct_path, cascade=False, **common)
+        build_missing_pyramid_levels(output_zarr_path=cascade_path, cascade=True, **common)
+
+        import zarr
+        direct_s1 = zarr.open_array(os.path.join(direct_path, "s1"), mode="r")[:]
+        cascade_s1 = zarr.open_array(os.path.join(cascade_path, "s1"), mode="r")[:]
+        np.testing.assert_array_equal(direct_s1, cascade_s1)
+
+        direct_s2 = zarr.open_array(os.path.join(direct_path, "s2"), mode="r")[:]
+        cascade_s2 = zarr.open_array(os.path.join(cascade_path, "s2"), mode="r")[:]
+        agreement = np.mean(direct_s2 == cascade_s2)
+        assert agreement > 0.8, f"expected high agreement, got {agreement:.2%}"
+
+    def test_cascade_resets_chain_at_existing_gap(self, tmp_path):
+        """If s1 is 'existing' (skipped, so cascade has no reader for its
+        contents), s2 must be built directly from s0 rather than
+        incorrectly chaining through a non-existent s1 array."""
+        rng = np.random.default_rng(5)
+        vol = rng.integers(low=0, high=4, size=(16, 16, 16), dtype=np.uint8)
+        out_path = str(tmp_path / "pyramid.zarr")
+        build_missing_pyramid_levels(
+            s0_reader=lambda o, s: vol[o[0]:o[0]+s[0], o[1]:o[1]+s[1], o[2]:o[2]+s[2]].copy(),
+            s0_dataset_shape_voxels=np.array(vol.shape),
+            s0_voxel_size_zyx=[1.0, 1.0, 1.0],
+            s0_translation_zyx=[0.5, 0.5, 0.5],
+            dtype=vol.dtype,
+            num_lods=3,
+            existing_factors={(2, 2, 2)},  # pretend s1 already exists
+            output_zarr_path=out_path,
+            downsample_func=downsample_labels_3d,
+            out_chunk_shape_voxels=(4, 4, 4),
+            cascade=True,
+        )
+        assert not os.path.isdir(os.path.join(out_path, "s1"))
+
+        import zarr
+        s2 = zarr.open_array(os.path.join(out_path, "s2"), mode="r")[:]
+        ref_s2, _ = downsample_labels_3d(vol, (4, 4, 4))
+        np.testing.assert_array_equal(s2, ref_s2)
 
 
 class TestSymlinkSafeCleanup:


### PR DESCRIPTION
@stuarteberg
## Summary
- Adds `downsample_cascade=True` option: chains each missing scale from the immediately preceding one (s_{k-1} -> s_k) instead of always downsampling directly from s0, bounding per-task memory/compute regardless of `num_lods`. Default stays direct-from-source (unchanged behavior)
- Matches the auto-built intermediate pyramid's zarr format (v2 or v3) to the input dataset's format, so s0 can be symlinked in safely without a version mismatch that breaks generic OME-zarr readers like neuroglancer
- Adds zarr v3 array creation/read/write support to the pyramid builder, plus a format-mismatch guard on the s0 symlink and v3-aware parsing of a prior run's pyramid metadata for reuse
- Clarifies (via logging/docstrings/README) that missing scales are auto-built transparently, and fixes a stale `pyramid_alignment_mode` default in the README (snap -> halo)
- Removes a no-op `wait_for_workers` call in `start_dask` (unconditional except swallowed its own timeout)